### PR TITLE
Simplify pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,30 +30,29 @@ and start application `honey_pool` in your app, then try in shell:
 1> logger:set_primary_config(level, info).
 ok
 
-2> honey_pool:get("https://example.com/").
-{ok,{200,
-     [{<<"accept-ranges">>,<<"bytes">>},
-      {<<"age">>,<<"104009">>},
-      {<<"cache-control">>,<<"max-age=604800">>},
-      {<<"content-type">>,<<"text/html; charset=UTF-8">>},
-      {<<"date">>,<<"Mon, 17 Jan 2022 07:45:39 GMT">>},
-      {<<"etag">>,<<"\"3147526947\"">>},
-      {<<"expires">>,<<"Mon, 24 Jan 2022 07:45:39 GMT">>},
-      {<<"last-modified">>,<<"Thu, 17 Oct 2019 07:18:26 GMT">>},
-      {<<"server">>,<<"ECS (oxr/836E)">>},
-      {<<"vary">>,<<"Accept-Encoding">>},
-      {<<"x-cache">>,<<"HIT">>},
-      {<<"content-length">>,<<"1256">>}],
-     <<"<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n  "...>>}}
+2> honey_pool:dump_state().
+[#{await_up_conns => #{},host_conns => #{},up_conns => #{}},
+ #{await_up_conns => #{},host_conns => #{},up_conns => #{}},
+ #{await_up_conns => #{},host_conns => #{},up_conns => #{}}]
 
-3> honey_pool:summarize_state().
-[#{host_conns =>
-       [{{"example.com",443,tls},
-         #{available_conns => 1,awaiting_conns => 0,
-           in_use_conns => 0}}],
-   total_conns => 1},
- #{host_conns => [],total_conns => 0},
- #{host_conns => [],total_conns => 0}]
+3> honey_pool:get("http://example.com/", 100).
+{error,{checkout,{timeout,await_up}}}
+
+4> honey_pool:dump_state().
+[#{await_up_conns => #{},
+   host_conns =>
+       #{{"example.com",80,tcp} =>
+             [{<0.195.0>,#Ref<0.485877779.3106144257.39748>,
+               #Ref<0.485877779.3106144257.39749>}]},
+   up_conns => #{<0.195.0> => {"example.com",80,tcp}}},
+ #{await_up_conns => #{},host_conns => #{},up_conns => #{}},
+ #{await_up_conns => #{},host_conns => #{},up_conns => #{}}]
+
+5> honey_pool:summarize_state().
+[#{host_conns => [{{"example.com",80,tcp},1}],
+   total_conns => #{await_up => 0,up => 1}},
+ #{host_conns => [],total_conns => #{await_up => 0,up => 0}},
+ #{host_conns => [],total_conns => #{await_up => 0,up => 0}}]
 ```
 
 

--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -7,29 +7,21 @@
           transport = tcp :: transport()
          }).
 
--record(connections, {
-          available = [] :: [active_conn()],
-          in_use = [] :: [active_conn()],
-          awaiting = [] :: [awaiting_conn()]
-         }).
-
 -record(state, {
-          new_conn :: fun((Host::string(), Port::integer(), Transport::transport())
-                          -> {ok, conn()} | {error, Reason::any()}),
           tabid :: ets:tid(),
+          gun_opts = #{} :: gun_opts(),
           idle_timeout = infinity :: timeout()
          }).
 
--type conn() :: {pid(), monitor_ref()}.
--type active_conn() :: {conn(), timer_ref()}.
--type awaiting_conn() :: {conn(), pid()}.
+-type gun_opts() :: gun:opts().
+-type gun_req_opts() :: gun:req_opts().
 
+-type conn() :: {pid(), monitor_ref()}.
+-type pool_conn() :: {pid(), monitor_ref(), timer_ref()}.
 -type monitor_ref() :: reference().
 -type timer_ref() :: reference()|no_ref.
 
 -type transport() :: tcp | tls.
 -type hostinfo() :: {Host::string(), Port::integer(), Transport::transport()}.
--type connections() :: #connections{}.
--type host_conns() :: #{ hostinfo() => connections() }.
 -type state() :: #state{}.
 -type uri() :: #uri{}.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -153,12 +153,6 @@ do_request({Pid, MRef}, Method, Path, Headers, Body, Opts, Timeout0) ->
                {error, Reason} ->
                    {error, {await, Reason}}
            end,
-    case gun:stream_info(Pid, StreamRef) of
-        {ok, #{state := running}} ->
-            gun:cancel(Pid, StreamRef);
-        _ ->
-            ok
-    end,
     ?LOG_DEBUG("(~p) conn: ~p, request: ~p, response: ~p",
                [self(), Pid, {Method, Path, ReqHeaders, Body, Opts}, Resp]),
     Resp.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -149,8 +149,12 @@ do_request({Pid, MRef}, Method, Path, Headers, Body, Opts, Timeout0) ->
                        {stream_error,protocol_error,
                         'Content-length header received in a 204 response. (RFC7230 3.3.2)'}
                       }} ->
-                   %% there exist servers that return content-length header
+                   %% there exist servers that return content-length header and handle such responses as ordinary 204 response
+                   gun:cancel(Pid, StreamRef),
                    {ok, {204, [], no_data}};
+               {error,{stream_error, _} = Reason} ->
+                   gun:cancel(Pid, StreamRef),
+                   {error, {await, Reason}};
                {error, timeout} ->
                    {error, {timeout, await}};
                {error, Reason} ->

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -142,6 +142,8 @@ do_request({Pid, MRef}, Method, Path, Headers, Body, Opts, Timeout0) ->
                            {error, {await_body, Reason}}
                    end;
                {response, nofin, Status, RespHeaders} ->
+                   %% stream is nofin but skip reading body
+                   gun:cancel(Pid, StreamRef),
                    {ok, {Status, RespHeaders, no_data}};
                {error,{stream_error,
                        {stream_error,protocol_error,

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -246,6 +246,6 @@ summarize_state(
     #{total_conns => #{up => maps:size(UC),
                        await_up => maps:size(AC)},
       host_conns => lists:sort(
-                      fun({_, A}, {_, B}) -> A < B end,
+                      fun({_, A}, {_, B}) -> A > B end,
                       HostConns
                      )}.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -163,6 +163,7 @@ do_request({Pid, MRef}, Method, Path, Headers, Body, Opts, Timeout0) ->
                    gun:cancel(Pid, StreamRef),
                    {error, {await, Reason}}
            end,
+    gun:flush(StreamRef),
     ?LOG_DEBUG("(~p) conn: ~p, request: ~p, response: ~p",
                [self(), Pid, {Method, Path, ReqHeaders, Body, Opts}, Resp]),
     Resp.

--- a/src/honey_pool_sup.erl
+++ b/src/honey_pool_sup.erl
@@ -29,7 +29,7 @@ init([]) ->
     SupFlags = #{strategy => one_for_one,
                  intensity => 0,
                  period => 1},
-    GunOpt = application:get_env(honey_pool, gun_opts, #{}),
+    GunOpts = application:get_env(honey_pool, gun_opts, #{}),
     IdleTimeout = application:get_env(honey_pool, idle_timeout, infinity),
     WpoolConfig = maps:to_list(
                     lists:foldr(
@@ -40,7 +40,7 @@ init([]) ->
                       [{workers, 2},
                        {overrun_warning, 300},
                        {worker, {honey_pool_worker,
-                                 [{gun_opts, GunOpt},
+                                 [{gun_opts, GunOpts},
                                   {idle_timeout, IdleTimeout}
                                  ]}}
                       ])

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -60,8 +60,6 @@ handle_call({checkout, HostInfo}, {Requester, _}, State) ->
     {reply, Ret, State};
 handle_call(dump_state, _From, State) ->
     {reply, dump_state(State), State};
-%handle_call(tabid, _From, State) ->
-%    {reply, State#state.tabid, State};
 handle_call(Req, From, State) ->
     ?LOG_WARNING("(~p) unhandled call (~p, ~p, ~p)", [self(), Req, From ,State]),
     {reply, {error, no_handler}, State}.

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -68,14 +68,14 @@ handle_cast({checkin, HostInfo, Pid}, State) ->
     ?LOG_DEBUG("(~p) checkin a conn: ~p -> ~p", [self(), HostInfo, Pid]),
     ok = conn_checkin(HostInfo, Pid, State),
     {noreply, State};
+handle_cast({cancel_await_up, Pid} = Req, State) ->
+    ?LOG_DEBUG("(~p) cancel await_up: ~p", [self(), Req]),
+    ok = conn_cancel_await_up(Pid, State),
+    {noreply, State};
 handle_cast(Req, State) ->
     ?LOG_WARNING("(~p) unhandled cast (~p, ~p)", [self(), Req, State]),
     {noreply, State}.
 
-handle_info({cancel_await_up, Pid} = Req, State) ->
-    ?LOG_DEBUG("(~p) cancel await_up: ~p", [self(), Req]),
-    ok = conn_cancel_await_up(Pid, State),
-    {noreply, State};
 handle_info({idle_timeout, Pid} = Req, State) ->
     ?LOG_DEBUG("(~p) idle timeout: ~p", [self(), Req]),
     ok = gun:close(Pid),

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -115,8 +115,8 @@ cancel_idle_timer(TRef) ->
     ok.
 
 -spec conn_checkout(HostInfo::hostinfo(), Requester::pid(), State::state()) ->
-    {ok, Pid::pid()} |
-    {await_up, {ReplyTo::pid(), Pid::pid()}} |
+    {ok, {ReturnTo::pid(), Pid::pid()}} |
+    {await_up, {ReturnTo::pid(), Pid::pid()}} |
     {error, Reason::term()}.
 conn_checkout(HostInfo, Requester, #state{tabid = TabId} = State) ->
     case ets:lookup(TabId, {hostinfo, HostInfo}) of
@@ -129,7 +129,7 @@ conn_checkout(HostInfo, Requester, #state{tabid = TabId} = State) ->
             ets:delete(TabId, {up, Pid}),
             cancel_idle_timer(TRef),
             demonitor(MRef),
-            {ok, Pid}
+            {ok, {self(), Pid}}
     end.
 
 -spec conn_open(HostInfo::hostinfo(), Requester::pid(), State::state()) ->

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -87,7 +87,7 @@ request_test_() ->
                                           [],
                                           5),
                                ?assertMatch(
-                                  {error,timeout},
+                                  {error, {timeout, await}},
                                   Actual)
                        end},
                       {"post: timeout=infinity",

--- a/test/honey_pool_worker_tests.erl
+++ b/test/honey_pool_worker_tests.erl
@@ -56,7 +56,7 @@ checkout_checkin_test_() ->
                        "initial checkout",
                        fun(Title) ->
                                %% checkout
-                               {await_up, {_ReturnTo, Pid}} = gen_server:call(?MODULE, {checkout, HostInfo}),
+                               {await_up, {ReturnTo, Pid}} = gen_server:call(?MODULE, {checkout, HostInfo}),
                                Ret1 = receive
                                           V1 -> V1
                                       end,
@@ -65,7 +65,7 @@ checkout_checkin_test_() ->
                                  host_conns := HostConns1
                                 } = gen_server:call(?MODULE, dump_state),
                                %% checkin
-                               gen_server:cast(?MODULE, {checkin, HostInfo, Pid}),
+                               gen_server:cast(ReturnTo, {checkin, HostInfo, Pid}),
                                #{await_up_conns := AwaitUpConns2,
                                  up_conns := UpConns2,
                                  host_conns := HostConns2
@@ -93,13 +93,13 @@ checkout_checkin_test_() ->
                        "second checkout",
                        fun(Title) ->
                                %% checkout
-                               {ok, Pid} = gen_server:call(?MODULE, {checkout, HostInfo}),
+                               {ok, {ReturnTo, Pid}} = gen_server:call(?MODULE, {checkout, HostInfo}),
                                #{await_up_conns := AwaitUpConns1,
                                  up_conns := UpConns1,
                                  host_conns := HostConns1
                                 } = gen_server:call(?MODULE, dump_state),
                                %% checkin
-                               gen_server:cast(?MODULE, {checkin, HostInfo, Pid}),
+                               gen_server:cast(ReturnTo, {checkin, HostInfo, Pid}),
                                #{await_up_conns := AwaitUpConns2,
                                  up_conns := UpConns2,
                                  host_conns := HostConns2
@@ -125,7 +125,7 @@ checkout_checkin_test_() ->
                        "sudden down",
                        fun(Title) ->
                                %% checkout
-                               {ok, Pid} = gen_server:call(?MODULE, {checkout, HostInfo}),
+                               {ok, {_ReturnTo, Pid}} = gen_server:call(?MODULE, {checkout, HostInfo}),
                                %% closing conn
                                gun:close(Pid),
                                #{await_up_conns := AwaitUpConns,
@@ -147,12 +147,12 @@ checkout_checkin_test_() ->
                        "after idle_timeout (500 ms)",
                        fun(Title) ->
                                %% checkout
-                               {await_up, {_ReturnTo, Pid}} = gen_server:call(?MODULE, {checkout, HostInfo}),
+                               {await_up, {ReturnTo, Pid}} = gen_server:call(?MODULE, {checkout, HostInfo}),
                                {gun_up, Pid, http} = receive
                                                          V1 -> V1
                                                      end,
                                %% checkin
-                               gen_server:cast(?MODULE, {checkin, HostInfo, Pid}),
+                               gen_server:cast(ReturnTo, {checkin, HostInfo, Pid}),
                                #{await_up_conns := AwaitUpConns1,
                                  up_conns := UpConns1,
                                  host_conns := HostConns1


### PR DESCRIPTION
* a pool only cares connections that are in the pool
* demonitor/monitor connection when transferring a connection in/out of the pool
* set owner pid when transferring a connection in/out of the pool