### PR TITLE
allow malformed query

### DIFF
--- a/src/honey_pool_uri.erl
+++ b/src/honey_pool_uri.erl
@@ -9,7 +9,13 @@
 -spec parse(string() | binary()) -> {ok, uri()} | {error, term()}.
 parse(Uri) when is_binary(Uri) ->
     parse(binary_to_list(Uri));
-parse(Uri) ->
+parse(Uri0) ->
+    {Uri, Query} = case string:split(Uri0, "?") of
+                       [U1, U2] ->
+                           {U1, U2};
+                       [U1] ->
+                           {U1, ""}
+                   end,
     try
         Parsed = uri_string:parse(Uri),
         Transport = case maps:find(scheme, Parsed) of
@@ -21,7 +27,6 @@ parse(Uri) ->
                    {ok, V} -> V;
                    _ -> "/"
                end,
-        Query = maps:get(query, Parsed, ""),
         Port = maps:get(port, Parsed, case Transport of
                                           tls -> 443;
                                           _ -> 80

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -71,6 +71,16 @@ request_test_() ->
                                   {ok, {200, _, _}},
                                   Actual)
                        end},
+                      {"get: with query",
+                       fun() ->
+                               Actual = honey_pool:get(
+                                          [Url, "/status/200/delay/50?foo=${FOO}&bar=][&buz=.."],
+                                          [],
+                                          infinity),
+                               ?assertMatch(
+                                  {ok, {200, _, _}},
+                                  Actual)
+                       end},
                       {"get: delay < timeout",
                        fun() ->
                                Actual = honey_pool:get(

--- a/test/honey_pool_uri_tests.erl
+++ b/test/honey_pool_uri_tests.erl
@@ -69,12 +69,19 @@ parse_uri_test_() ->
               end
              },
              {
-              <<"http://hogehoge/?hoge={HOGE}">>,
-              fun(Actual) ->
-                      ?_assertEqual({error,
-                                     {{badmap,
-                                       {error, invalid_uri, ":"}},
-                                      "http://hogehoge/?hoge={HOGE}"}}, Actual)
+              <<"http://hogehoge/?hoge=${HOGE}&fuga=..&foo=]|">>,
+              fun({ok, Actual}) ->
+                      Expected = {ok, #uri{
+                                         host = "hogehoge",
+                                         path = "/",
+                                         query = "hoge=${HOGE}&fuga=..&foo=]|",
+                                         pathquery = "/?hoge=${HOGE}&fuga=..&foo=]|",
+                                         port = 80,
+                                         transport = tcp
+                                        }},
+                      ?_assertEqual(Expected, {ok, Actual#uri{
+                                                     pathquery = lists:flatten(Actual#uri.pathquery)
+                                                    }})
               end
              }
             ],


### PR DESCRIPTION
It does't matter if url is invalid.
We just send requests as much as possible.