### PR TITLE
Worker as connection owner

### DIFF
--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -17,9 +17,7 @@
 -type gun_req_opts() :: gun:req_opts().
 
 -type conn() :: {pid(), monitor_ref()}.
--type pool_conn() :: {pid(), monitor_ref(), timer_ref()}.
 -type monitor_ref() :: reference().
--type timer_ref() :: reference()|no_ref.
 
 -type transport() :: tcp | tls.
 -type hostinfo() :: {Host::string(), Port::integer(), Transport::transport()}.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -5,7 +5,8 @@
          post/2, post/3, post/4, post/5,
          request/6,
          return_to/3,
-         dump_state/0, summarize_state/0
+         dump_state/0,
+         summarize_state/0
         ]).
 
 -include_lib("kernel/include/logger.hrl").
@@ -19,56 +20,68 @@
 
 -type method() :: binary().
 -type req_headers() :: gun:req_headers().
--type resp() :: {ok, {status(), resp_headers(), binary()|no_data}} | {timeout, term()} | {error, Reason::any()}.
+-type resp() ::
+{ok, {status(), resp_headers(), binary() | no_data}}
+| {timeout, term()}
+| {error, Reason :: any()}.
 -type resp_headers() :: gun:resp_headers().
 -type status() :: integer().
 -type url() :: string().
 
--spec get(Url::url()) -> resp().
+-spec get(Url :: url()) -> resp().
 get(Url) ->
     get(Url, []).
 
--spec get(Url::url(), Headers::req_headers()|timeout()) -> resp().
+-spec get(Url :: url(), Headers :: req_headers() | timeout()) -> resp().
 get(Url, Headers) when is_list(Headers) ->
     get(Url, Headers, #{});
 get(Url, Timeout) ->
     get(Url, [], Timeout).
 
--spec get(Url::url(), Headers::req_headers(), Opts::gun_req_opts()|timeout()) -> resp().
+-spec get(Url :: url(), Headers :: req_headers(), Opts :: gun_req_opts() | timeout()) -> resp().
 get(Url, Headers, Opts) when is_map(Opts) ->
     get(Url, Headers, Opts, infinity);
 get(Url, Headers, Timeout) ->
     get(Url, Headers, #{}, Timeout).
 
--spec get(Url::url(), Headers::req_headers(), Opts::gun_req_opts(), Timeout::timeout()) -> resp().
+-spec get(Url :: url(), Headers :: req_headers(), Opts :: gun_req_opts(), Timeout :: timeout()) ->
+    resp().
 get(Url, Headers, Opts, Timeout) ->
     request(?METHOD_GET, Url, Headers, <<>>, Opts, Timeout).
 
--spec post(Url::url(), Headers::req_headers()) -> resp().
+-spec post(Url :: url(), Headers :: req_headers()) -> resp().
 post(Url, Headers) ->
     post(Url, Headers, <<>>).
 
--spec post(Url::url(), Headers::req_headers(), Body::binary()) -> resp().
+-spec post(Url :: url(), Headers :: req_headers(), Body :: binary()) -> resp().
 post(Url, Headers, Body) ->
     post(Url, Headers, Body, #{}).
 
--spec post(Url::url(), Headers::req_headers(), Body::binary(), Opts::gun_req_opts()|timeout()) -> resp().
+-spec post(
+        Url :: url(), Headers :: req_headers(), Body :: binary(), Opts :: gun_req_opts() | timeout()
+       ) -> resp().
 post(Url, Headers, Body, Opts) when is_map(Opts) ->
     post(Url, Headers, Body, Opts, infinity);
 post(Url, Headers, Body, Timeout) ->
     post(Url, Headers, Body, #{}, Timeout).
 
--spec post(Url::url(), Headers::req_headers(), Body::binary(), Opts::gun_req_opts(), Timeout::timeout()) -> resp().
+-spec post(
+        Url :: url(),
+        Headers :: req_headers(),
+        Body :: binary(),
+        Opts :: gun_req_opts(),
+        Timeout :: timeout()
+       ) -> resp().
 post(Url, Headers, Body, Opt, Timeout) ->
     request(?METHOD_POST, Url, Headers, Body, Opt, Timeout).
 
 -spec request(
-        Method::method(),
-        Url::url(),
-        Headers::req_headers(),
-        Body::binary() | no_data,
-        Opts::gun_req_opts(),
-        Timeout0::timeout()
+        Method :: method(),
+        Url :: url(),
+        Headers :: req_headers(),
+        Body :: binary() | no_data,
+        Opts :: gun_req_opts(),
+        Timeout0 :: timeout()
        ) -> resp().
 request(Method, Url, Headers, Body, Opts, Timeout0) ->
     case honey_pool_uri:parse(Url) of
@@ -76,8 +89,10 @@ request(Method, Url, Headers, Body, Opts, Timeout0) ->
             HostInfo = {U#uri.host, U#uri.port, U#uri.transport},
             {Elapsed, Checkout} = timer:tc(
                                     fun checkout/2,
-                                    [HostInfo,
-                                     Timeout0]
+                                    [
+                                     HostInfo,
+                                     Timeout0
+                                    ]
                                    ),
             case Checkout of
                 {ok, {ReturnTo, {Pid, _} = Conn}} ->
@@ -92,13 +107,19 @@ request(Method, Url, Headers, Body, Opts, Timeout0) ->
                               ),
                     case Result of
                         {ok, {Status, _, _}} ->
-                            ?LOG_DEBUG("(~p) (conn: ~p) ~p ~p -> ~.10b", [self(), Pid, Method, Url, Status]),
+                            ?LOG_DEBUG("(~p) (conn: ~p) ~p ~p -> ~.10b", [
+                                                                          self(), Pid, Method, Url, Status
+                                                                         ]),
                             checkin(ReturnTo, HostInfo, Conn);
                         {error, {timeout, _}} = TimeoutErr ->
-                            ?LOG_DEBUG("(~p) (conn: ~p) ~p ~p -> ~p", [self(), Pid, Method, Url, TimeoutErr]),
+                            ?LOG_DEBUG("(~p) (conn: ~p) ~p ~p -> ~p", [
+                                                                       self(), Pid, Method, Url, TimeoutErr
+                                                                      ]),
                             cleanup(Conn);
                         ReqErr ->
-                            ?LOG_DEBUG("(~p) (conn: ~p) ~p ~p -> ~p", [self(), Pid, Method, Url, ReqErr]),
+                            ?LOG_DEBUG("(~p) (conn: ~p) ~p ~p -> ~p", [
+                                                                       self(), Pid, Method, Url, ReqErr
+                                                                      ]),
                             cleanup(Conn)
                     end,
                     Result;
@@ -110,68 +131,72 @@ request(Method, Url, Headers, Body, Opts, Timeout0) ->
     end.
 
 -spec do_request(
-        Conn::conn(),
-        Method::method(),
-        Path::url(),
-        Headers::req_headers(),
-        Body::iodata(),
-        Opts::gun_req_opts(),
-        Timeout0::timeout()
+        Conn :: conn(),
+        Method :: method(),
+        Path :: url(),
+        Headers :: req_headers(),
+        Body :: iodata(),
+        Opts :: gun_req_opts(),
+        Timeout0 :: timeout()
        ) -> resp().
 do_request({Pid, MRef}, Method, Path, Headers, Body, Opts, Timeout0) ->
     ReqHeaders = headers(Headers),
     StreamRef = gun:request(Pid, Method, Path, ReqHeaders, Body, Opts),
-    {Elapsed, Result}
-    = timer:tc(
-        fun gun:await/4,
-        [Pid, StreamRef, Timeout0, MRef]
-       ),
-    Resp = case Result of
-               {response, fin, Status, RespHeaders} ->
-                   {ok, {Status, RespHeaders, no_data}};
-               {response, nofin, 200, RespHeaders} ->
-                   %% read body only when status code is 200
-                   Timeout1 = next_timeout(Timeout0, Elapsed),
-                   case gun:await_body(Pid, StreamRef, Timeout1, MRef) of
-                       {ok, RespBody} ->
-                           {ok, {200, RespHeaders, RespBody}};
-                       {error, timeout} ->
-                           {error, {timeout, await_body}};
-                       {error, Reason} ->
-                           {error, {await_body, Reason}}
-                   end;
-               {response, nofin, Status, RespHeaders} ->
-                   %% stream is nofin but skip reading body
-                   gun:cancel(Pid, StreamRef),
-                   {ok, {Status, RespHeaders, no_data}};
-               {error,{stream_error,
-                       {stream_error,protocol_error,
-                        'Content-length header received in a 204 response. (RFC7230 3.3.2)'}
-                      }} ->
-                   %% there exist servers that return content-length header and handle such responses as ordinary 204 response
-                   {ok, {204, [], no_data}};
-               {error,{stream_error, _} = Reason} ->
-                   {error, {await, Reason}};
-               {error, timeout} ->
-                   {error, {timeout, await}};
-               {error, Reason} ->
-                   {error, {await, Reason}}
-           end,
-    ?LOG_DEBUG("(~p) conn: ~p, request: ~p, response: ~p",
-               [self(), Pid, {Method, Path, ReqHeaders, Body, Opts}, Resp]),
+    {Elapsed, Result} =
+    timer:tc(
+      fun gun:await/4,
+      [Pid, StreamRef, Timeout0, MRef]
+     ),
+    Resp =
+    case Result of
+        {response, fin, Status, RespHeaders} ->
+            {ok, {Status, RespHeaders, no_data}};
+        {response, nofin, 200, RespHeaders} ->
+            %% read body only when status code is 200
+            Timeout1 = next_timeout(Timeout0, Elapsed),
+            case gun:await_body(Pid, StreamRef, Timeout1, MRef) of
+                {ok, RespBody} ->
+                    {ok, {200, RespHeaders, RespBody}};
+                {error, timeout} ->
+                    {error, {timeout, await_body}};
+                {error, Reason} ->
+                    {error, {await_body, Reason}}
+            end;
+        {response, nofin, Status, RespHeaders} ->
+            %% stream is nofin but skip reading body
+            gun:cancel(Pid, StreamRef),
+            {ok, {Status, RespHeaders, no_data}};
+        {error,
+         {stream_error,
+          {stream_error, protocol_error,
+           'Content-length header received in a 204 response. (RFC7230 3.3.2)'}}} ->
+            %% there exist servers that return content-length header and handle such responses as ordinary 204 response
+            {ok, {204, [], no_data}};
+        {error, {stream_error, _} = Reason} ->
+            {error, {await, Reason}};
+        {error, timeout} ->
+            {error, {timeout, await}};
+        {error, Reason} ->
+            {error, {await, Reason}}
+    end,
+    ?LOG_DEBUG(
+       "(~p) conn: ~p, request: ~p, response: ~p",
+       [self(), Pid, {Method, Path, ReqHeaders, Body, Opts}, Resp]
+      ),
     Resp.
-
 
 -spec headers(req_headers()) -> req_headers().
 headers(Headers) ->
-    [{<<"User-Agent">>, ?USER_AGENT}
-     | Headers].
+    [
+     {<<"User-Agent">>, ?USER_AGENT}
+     | Headers
+    ].
 
--spec next_timeout(Timeout0::timeout(), MicroSec::integer()) -> timeout().
+-spec next_timeout(Timeout0 :: timeout(), MicroSec :: integer()) -> timeout().
 next_timeout(infinity, _) ->
     infinity;
 next_timeout(Timeout0, MicroSec) ->
-    Interval = trunc(MicroSec/1000),
+    Interval = trunc(MicroSec / 1000),
     case Timeout0 > Interval of
         true ->
             Timeout0 - Interval;
@@ -179,13 +204,14 @@ next_timeout(Timeout0, MicroSec) ->
             0
     end.
 
--spec checkout(HostInfo::hostinfo(), Timeout0::timeout()) -> {ok, {ReturnTo::pid(), Conn::conn()}} | {error, Reason::term()}.
+-spec checkout(HostInfo :: hostinfo(), Timeout0 :: timeout()) ->
+    {ok, {ReturnTo :: pid(), Conn :: conn()}} | {error, Reason :: term()}.
 checkout(HostInfo, Timeout0) ->
-    {Elapsed, Result}
-    = timer:tc(
-        fun wpool:call/4,
-        [?WORKER, {checkout, HostInfo}, best_worker, Timeout0]
-       ),
+    {Elapsed, Result} =
+    timer:tc(
+      fun wpool:call/4,
+      [?WORKER, {checkout, HostInfo}, best_worker, Timeout0]
+     ),
     try Result of
         {ok, {await_up, {ReturnTo, Pid}}} ->
             MRef = monitor(process, Pid),
@@ -210,50 +236,61 @@ checkout(HostInfo, Timeout0) ->
             {error, {checkout, Err}}
     end.
 
--spec cancel_await_up(ReturnTo::pid(), Conn::conn()) -> ok.
+-spec cancel_await_up(ReturnTo :: pid(), Conn :: conn()) -> ok.
 cancel_await_up(ReturnTo, {Pid, MRef}) ->
     demonitor(MRef),
-    gun:flush(Pid),
     return_to(ReturnTo, Pid, {cancel_await_up, Pid}).
 
--spec checkin(ReturnTo::pid(), HostInfo::hostinfo(), Conn::conn()) -> ok.
+-spec checkin(ReturnTo :: pid(), HostInfo :: hostinfo(), Conn :: conn()) -> ok.
 checkin(ReturnTo, HostInfo, {Pid, MRef}) ->
     demonitor(MRef, [flush]),
-    gun:flush(Pid),
     return_to(ReturnTo, Pid, {checkin, HostInfo, Pid}).
 
--spec cleanup(Conn::conn()) -> ok.
+-spec cleanup(Conn :: conn()) -> ok.
 cleanup({Pid, MRef}) ->
     demonitor(MRef, [flush]),
     gun:close(Pid),
     ok.
 
--spec return_to(ReturnTo::pid(), Pid::pid(), Msg::term()) -> ok.
+-spec return_to(ReturnTo :: pid(), Pid :: pid(), Msg :: term()) -> ok.
 return_to(ReturnTo, Pid, Msg) ->
-    gun:set_owner(Pid, ReturnTo),
+    %gun:set_owner(Pid, ReturnTo),
+    gun:flush(Pid),
     gen_server:cast(ReturnTo, Msg).
 
 -spec dump_state() -> [map()].
 dump_state() ->
-    [gen_server:call(Proc, dump_state)
-     || Proc <- wpool:get_workers(honey_pool_worker)].
+    [
+     gen_server:call(Proc, dump_state)
+     || Proc <- wpool:get_workers(honey_pool_worker)
+    ].
 
 -spec summarize_state() -> [map()].
 summarize_state() ->
     [summarize_state(S) || S <- dump_state()].
 
 summarize_state(
-  #{up_conns := UC,
+  #{
+    up_conns := UC,
     await_up_conns := AC,
-    host_conns := HC}
+    host_conns := HC
+   }
  ) ->
     HostConns = lists:foldl(
                   fun({Host, Conns}, Acc) ->
                           [{Host, length(Conns)} | Acc]
-                  end, [], maps:to_list(HC)),
-    #{total_conns => #{up => maps:size(UC),
-                       await_up => maps:size(AC)},
+                  end,
+                  [],
+                  maps:to_list(HC)
+                 ),
+    #{
+      total_conns => #{
+                       up => maps:size(UC),
+                       await_up => maps:size(AC)
+                      },
       host_conns => lists:sort(
                       fun({_, A}, {_, B}) -> A > B end,
                       HostConns
-                     )}.
+                     )
+     }.
+

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -271,26 +271,28 @@ summarize_state() ->
 
 summarize_state(
   #{
-    up_conns := UC,
     await_up_conns := AC,
-    host_conns := HC
+    checked_in_conns := IC,
+    checked_out_conns := OC,
+    pool_conns := PC
    }
  ) ->
-    HostConns = lists:foldl(
-                  fun({Host, Conns}, Acc) ->
-                          [{Host, length(Conns)} | Acc]
+    PoolConns = lists:foldl(
+                  fun({Host, Pids}, Acc) ->
+                          [{Host, length(Pids)} | Acc]
                   end,
                   [],
-                  maps:to_list(HC)
+                  maps:to_list(PC)
                  ),
     #{
       total_conns => #{
-                       up => maps:size(UC),
-                       await_up => maps:size(AC)
+                       await_up => maps:size(AC),
+                       checked_in => maps:size(IC),
+                       checked_out => maps:size(OC)
                       },
-      host_conns => lists:sort(
+      pool_conns => lists:sort(
                       fun({_, A}, {_, B}) -> A > B end,
-                      HostConns
+                      PoolConns
                      )
      }.
 

--- a/src/honey_pool_sup.erl
+++ b/src/honey_pool_sup.erl
@@ -26,31 +26,35 @@ start_link() ->
 %%                  type => worker(),       % optional
 %%                  modules => modules()}   % optional
 init([]) ->
-    SupFlags = #{strategy => one_for_one,
+    SupFlags = #{
+                 strategy => one_for_one,
                  intensity => 0,
-                 period => 1},
+                 period => 1
+                },
     GunOpts = application:get_env(honey_pool, gun_opts, #{}),
     IdleTimeout = application:get_env(honey_pool, idle_timeout, infinity),
     WpoolConfig = maps:to_list(
                     lists:foldr(
-                    fun({K, V}, Acc) -> Acc#{K => V} end,
-                    #{},
-                    lists:flatten(
-                      application:get_env(honey_pool, wpool, []),
-                      [{workers, 2},
-                       {overrun_warning, 300},
-                       {worker, {honey_pool_worker,
-                                 [{gun_opts, GunOpts},
-                                  {idle_timeout, IdleTimeout}
-                                 ]}}
-                      ])
-                   )),
+                      fun({K, V}, Acc) -> Acc#{K => V} end,
+                      #{},
+                      lists:flatten(
+                        application:get_env(honey_pool, wpool, []),
+                        [
+                         {workers, 2},
+                         {overrun_warning, 300},
+                         {worker,
+                          {honey_pool_worker, [
+                                               {gun_opts, GunOpts},
+                                               {idle_timeout, IdleTimeout}
+                                              ]}}
+                        ]
+                       )
+                     )
+                   ),
     ChildSpecs = [
                   #{
                     id => honey_pool_workers,
-                    start => {wpool, start_pool,
-                              [honey_pool_worker, WpoolConfig]
-                             },
+                    start => {wpool, start_pool, [honey_pool_worker, WpoolConfig]},
                     restart => permanent,
                     type => worker
                    }
@@ -58,3 +62,4 @@ init([]) ->
     {ok, {SupFlags, ChildSpecs}}.
 
 %% internal functions
+

--- a/src/honey_pool_uri.erl
+++ b/src/honey_pool_uri.erl
@@ -10,35 +10,43 @@
 parse(Uri) when is_binary(Uri) ->
     parse(binary_to_list(Uri));
 parse(Uri0) ->
-    {Uri, Query} = case string:split(Uri0, "?") of
-                       [U1, U2] ->
-                           {U1, U2};
-                       [U1] ->
-                           {U1, ""}
-                   end,
+    {Uri, Query} =
+    case string:split(Uri0, "?") of
+        [U1, U2] ->
+            {U1, U2};
+        [U1] ->
+            {U1, ""}
+    end,
     try
         Parsed = uri_string:parse(Uri),
-        Transport = case maps:find(scheme, Parsed) of
-                        {ok, "https"} -> tls;
-                        _ -> tcp
-                    end,
-        Path = case maps:find(path, Parsed) of
-                   {ok, ""} -> "/";
-                   {ok, V} -> V;
-                   _ -> "/"
-               end,
-        Port = maps:get(port, Parsed, case Transport of
-                                          tls -> 443;
-                                          _ -> 80
-                                      end),
+        Transport =
+        case maps:find(scheme, Parsed) of
+            {ok, "https"} -> tls;
+            _ -> tcp
+        end,
+        Path =
+        case maps:find(path, Parsed) of
+            {ok, ""} -> "/";
+            {ok, V} -> V;
+            _ -> "/"
+        end,
+        Port = maps:get(
+                 port,
+                 Parsed,
+                 case Transport of
+                     tls -> 443;
+                     _ -> 80
+                 end
+                ),
         {ok, #uri{
                 host = maps:get(host, Parsed, ""),
                 path = Path,
                 query = Query,
-                pathquery = case Query of
-                                [] -> Path;
-                                _ -> [Path, "?", Query]
-                            end,
+                pathquery =
+                case Query of
+                    [] -> Path;
+                    _ -> [Path, "?", Query]
+                end,
                 port = Port,
                 transport = Transport
                }}
@@ -46,3 +54,4 @@ parse(Uri0) ->
         _:Err ->
             {error, {Err, Uri}}
     end.
+

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -275,7 +275,7 @@ conn_down(Pid, #state{tabid = TabId}) ->
     case ets:lookup(TabId, {pid, Pid}) of
         [{_, Conn}] ->
             HostInfo = Conn#conn.hostinfo,
-            demonitor(Conn#conn.monitor_ref),
+            demonitor(Conn#conn.monitor_ref, [flush]),
             cancel_idle_timer(Conn#conn.timer_ref),
             ets:delete(TabId, {pid, Pid}),
             case ets:lookup(TabId, {pool, HostInfo}) of

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -14,7 +14,8 @@ init(Req0, State) ->
             StatusCode,
             #{<<"content-type">> => <<"text/plain">>},
             <<"Hello">>,
-            Req0),
+            Req0
+           ),
     {ok, Req, State}.
 
 request_test_() ->
@@ -26,27 +27,35 @@ request_test_() ->
                                 {ok, Started} = application:ensure_all_started(App),
                                 Started
                         end,
-                        [cowboy, honey_pool])),
+                        [cowboy, honey_pool]
+                       )
+                     ),
              Dispatch = cowboy_router:compile(
-                          [{'_',
-                            [{"/status/:status_code/delay/:delay_millisec", ?MODULE, []}]
-                           }]),
+                          [{'_', [{"/status/:status_code/delay/:delay_millisec", ?MODULE, []}]}]
+                         ),
              {ok, _} = cowboy:start_clear(
                          ?MODULE,
                          [{port, 0}],
-                         #{env => #{dispatch => Dispatch}}),
-             #{apps => Apps,
+                         #{env => #{dispatch => Dispatch}}
+                        ),
+             #{
+               apps => Apps,
                url => io_lib:format(
                         "http://localhost:~.10b",
-                        [ranch:get_port(?MODULE)])
+                        [ranch:get_port(?MODULE)]
+                       )
               }
      end,
      fun(#{apps := Apps}) ->
              error_logger:tty(false),
              ok = cowboy:stop_listener(?MODULE),
-             try lists:map(fun(App) ->
-                                   application:stop(App)
-                           end, Apps)
+             try
+                 lists:map(
+                   fun(App) ->
+                           application:stop(App)
+                   end,
+                   Apps
+                  )
              after
                  error_logger:tty(true)
              end,
@@ -54,78 +63,85 @@ request_test_() ->
      end,
      fun(#{url := Url}) ->
              Cases = [
-                      {"get: not found",
-                       fun() ->
-                               Actual = honey_pool:get([Url, "/foobar"]),
-                               ?assertMatch(
-                                  {ok, {404, _, _}},
-                                  Actual)
-                       end},
-                      {"get: timeout=infinity",
-                       fun() ->
-                               Actual = honey_pool:get(
-                                          [Url, "/status/200/delay/500"],
-                                          [],
-                                          infinity),
-                               ?assertMatch(
-                                  {ok, {200, _, _}},
-                                  Actual)
-                       end},
-                      {"get: with query",
-                       fun() ->
-                               Actual = honey_pool:get(
-                                          [Url, "/status/200/delay/50?foo=${FOO}&bar=][&buz=.."],
-                                          [],
-                                          infinity),
-                               ?assertMatch(
-                                  {ok, {200, _, _}},
-                                  Actual)
-                       end},
-                      {"get: delay < timeout",
-                       fun() ->
-                               Actual = honey_pool:get(
-                                          [Url, "/status/200/delay/50"],
-                                          [],
-                                          1000),
-                               ?assertMatch(
-                                  {ok, {200, _, _}},
-                                  Actual)
-                       end},
-                      {"get: delay > timeout",
-                       fun() ->
-                               Actual = honey_pool:get(
-                                          [Url, "/status/200/delay/100"],
-                                          [],
-                                          5),
-                               ?assertMatch(
-                                  {error, {timeout, await}},
-                                  Actual)
-                       end},
-                      {"post: timeout=infinity",
-                       fun() ->
-                               Actual = honey_pool:post(
-                                          [Url, "/status/200/delay/500"],
-                                          [],
-                                          <<"req data">>,
-                                          infinity),
-                               ?assertMatch(
-                                  {ok, {200, _, _}},
-                                  Actual)
-                       end},
-                      {"get: status=400",
-                       fun() ->
-                               Actual = honey_pool:post(
-                                          [Url, "/status/400/delay/50"],
-                                          [],
-                                          <<"req data">>,
-                                          infinity),
-                               ?assertMatch(
-                                  {ok, {400, _, no_data}},
-                                  Actual)
-                       end}
+                      {"get: not found", fun() ->
+                                                 Actual = honey_pool:get([Url, "/foobar"]),
+                                                 ?assertMatch(
+                                                    {ok, {404, _, _}},
+                                                    Actual
+                                                   )
+                                         end},
+                      {"get: timeout=infinity", fun() ->
+                                                        Actual = honey_pool:get(
+                                                                   [Url, "/status/200/delay/500"],
+                                                                   [],
+                                                                   infinity
+                                                                  ),
+                                                        ?assertMatch(
+                                                           {ok, {200, _, _}},
+                                                           Actual
+                                                          )
+                                                end},
+                      {"get: with query", fun() ->
+                                                  Actual = honey_pool:get(
+                                                             [Url, "/status/200/delay/50?foo=${FOO}&bar=][&buz=.."],
+                                                             [],
+                                                             infinity
+                                                            ),
+                                                  ?assertMatch(
+                                                     {ok, {200, _, _}},
+                                                     Actual
+                                                    )
+                                          end},
+                      {"get: delay < timeout", fun() ->
+                                                       Actual = honey_pool:get(
+                                                                  [Url, "/status/200/delay/50"],
+                                                                  [],
+                                                                  1000
+                                                                 ),
+                                                       ?assertMatch(
+                                                          {ok, {200, _, _}},
+                                                          Actual
+                                                         )
+                                               end},
+                      {"get: delay > timeout", fun() ->
+                                                       Actual = honey_pool:get(
+                                                                  [Url, "/status/200/delay/100"],
+                                                                  [],
+                                                                  5
+                                                                 ),
+                                                       ?assertMatch(
+                                                          {error, {timeout, await}},
+                                                          Actual
+                                                         )
+                                               end},
+                      {"post: timeout=infinity", fun() ->
+                                                         Actual = honey_pool:post(
+                                                                    [Url, "/status/200/delay/500"],
+                                                                    [],
+                                                                    <<"req data">>,
+                                                                    infinity
+                                                                   ),
+                                                         ?assertMatch(
+                                                            {ok, {200, _, _}},
+                                                            Actual
+                                                           )
+                                                 end},
+                      {"get: status=400", fun() ->
+                                                  Actual = honey_pool:post(
+                                                             [Url, "/status/400/delay/50"],
+                                                             [],
+                                                             <<"req data">>,
+                                                             infinity
+                                                            ),
+                                                  ?assertMatch(
+                                                     {ok, {400, _, no_data}},
+                                                     Actual
+                                                    )
+                                          end}
                      ],
              F = fun({Title, Test}) ->
                          [{Title, Test}]
                  end,
              lists:map(F, Cases)
      end}.
+

--- a/test/honey_pool_uri_tests.erl
+++ b/test/honey_pool_uri_tests.erl
@@ -8,44 +8,45 @@ parse_uri_test_() ->
              {
               "http://foobar.com",
               fun(Actual) ->
-                      Expected = {ok,
-                                  #uri{
-                                     host = "foobar.com",
-                                     path = "/",
-                                     query = "",
-                                     pathquery = "/",
-                                     port = 80,
-                                     transport = tcp
-                                    }},
+                      Expected =
+                      {ok, #uri{
+                              host = "foobar.com",
+                              path = "/",
+                              query = "",
+                              pathquery = "/",
+                              port = 80,
+                              transport = tcp
+                             }},
                       ?_assertEqual(Expected, Actual)
               end
              },
              {
               "https://foobar.com/",
               fun(Actual) ->
-                      Expected = {ok,
-                                  #uri{
-                                     host = "foobar.com",
-                                     path = "/",
-                                     query = "",
-                                     pathquery = "/",
-                                     port = 443,
-                                     transport = tls
-                                    }},
+                      Expected =
+                      {ok, #uri{
+                              host = "foobar.com",
+                              path = "/",
+                              query = "",
+                              pathquery = "/",
+                              port = 443,
+                              transport = tls
+                             }},
                       ?_assertEqual(Expected, Actual)
               end
              },
              {
               "https://foobar.com:8443/hoge/fuga?foo=bar&bar=foo",
               fun({ok, Actual}) ->
-                      Expected = {ok, #uri{
-                                         host = "foobar.com",
-                                         path = "/hoge/fuga",
-                                         query = "foo=bar&bar=foo",
-                                         pathquery = "/hoge/fuga?foo=bar&bar=foo",
-                                         port = 8443,
-                                         transport = tls
-                                        }},
+                      Expected =
+                      {ok, #uri{
+                              host = "foobar.com",
+                              path = "/hoge/fuga",
+                              query = "foo=bar&bar=foo",
+                              pathquery = "/hoge/fuga?foo=bar&bar=foo",
+                              port = 8443,
+                              transport = tls
+                             }},
                       Actual1 = Actual#uri{
                                   pathquery = lists:flatten(Actual#uri.pathquery)
                                  },
@@ -55,33 +56,41 @@ parse_uri_test_() ->
              {
               <<"https://foobar.com:8443/hoge/fuga?foo=bar&bar=foo">>,
               fun({ok, Actual}) ->
-                      Expected = {ok, #uri{
-                                         host = "foobar.com",
-                                         path = "/hoge/fuga",
-                                         query = "foo=bar&bar=foo",
-                                         pathquery = "/hoge/fuga?foo=bar&bar=foo",
-                                         port = 8443,
-                                         transport = tls
-                                        }},
-                      ?_assertEqual(Expected, {ok, Actual#uri{
-                                                     pathquery = lists:flatten(Actual#uri.pathquery)
-                                                    }})
+                      Expected =
+                      {ok, #uri{
+                              host = "foobar.com",
+                              path = "/hoge/fuga",
+                              query = "foo=bar&bar=foo",
+                              pathquery = "/hoge/fuga?foo=bar&bar=foo",
+                              port = 8443,
+                              transport = tls
+                             }},
+                      ?_assertEqual(
+                         Expected,
+                         {ok, Actual#uri{
+                                pathquery = lists:flatten(Actual#uri.pathquery)
+                               }}
+                        )
               end
              },
              {
               <<"http://hogehoge/?hoge=${HOGE}&fuga=..&foo=]|">>,
               fun({ok, Actual}) ->
-                      Expected = {ok, #uri{
-                                         host = "hogehoge",
-                                         path = "/",
-                                         query = "hoge=${HOGE}&fuga=..&foo=]|",
-                                         pathquery = "/?hoge=${HOGE}&fuga=..&foo=]|",
-                                         port = 80,
-                                         transport = tcp
-                                        }},
-                      ?_assertEqual(Expected, {ok, Actual#uri{
-                                                     pathquery = lists:flatten(Actual#uri.pathquery)
-                                                    }})
+                      Expected =
+                      {ok, #uri{
+                              host = "hogehoge",
+                              path = "/",
+                              query = "hoge=${HOGE}&fuga=..&foo=]|",
+                              pathquery = "/?hoge=${HOGE}&fuga=..&foo=]|",
+                              port = 80,
+                              transport = tcp
+                             }},
+                      ?_assertEqual(
+                         Expected,
+                         {ok, Actual#uri{
+                                pathquery = lists:flatten(Actual#uri.pathquery)
+                               }}
+                        )
               end
              }
             ],
@@ -90,3 +99,4 @@ parse_uri_test_() ->
                 [{Input, Test(Actual)}]
         end,
     lists:map(F, Cases).
+

--- a/test/honey_pool_worker_tests.erl
+++ b/test/honey_pool_worker_tests.erl
@@ -11,43 +11,55 @@ init(Req0, State) ->
             200,
             #{<<"content-type">> => <<"text/plain">>},
             <<"Hello">>,
-            Req0),
+            Req0
+           ),
     {ok, Req, State}.
 
 boot_server() ->
     {ok, Apps} = application:ensure_all_started(cowboy),
     Dispatch = cowboy_router:compile(
-                 [{'_',
-                   [{"/", ?MODULE, []}]
-                  }]),
+                 [{'_', [{"/", ?MODULE, []}]}]
+                ),
     {ok, _} = cowboy:start_clear(
                 ?LISTENER,
                 [{port, 0}],
-                #{env => #{dispatch => Dispatch}}),
+                #{env => #{dispatch => Dispatch}}
+               ),
     Port = ranch:get_port(?LISTENER),
-    [{apps, Apps},
+    [
+     {apps, Apps},
      {port, Port},
-     {hostinfo, {"localhost", Port, tcp}}].
+     {hostinfo, {"localhost", Port, tcp}}
+    ].
 
 checkout_checkin_test_() ->
     {setup,
      fun() ->
              Config = boot_server(),
              {ok, Apps} = application:ensure_all_started(gun),
-             {ok, Pid} = gen_server:start_link({local, ?MODULE}, honey_pool_worker, [{idle_timeout, 500}], []),
-             [{apps, lists:flatten(Apps, proplists:get_value(apps, Config))},
-              {pid, Pid} |
-              Config]
+             {ok, Pid} = gen_server:start_link(
+                           {local, ?MODULE}, honey_pool_worker, [{idle_timeout, 500}], []
+                          ),
+             [
+              {apps, lists:flatten(Apps, proplists:get_value(apps, Config))},
+              {pid, Pid}
+              | Config
+             ]
      end,
      fun(Config) ->
              ok = gen_server:stop(?MODULE),
              cowboy:stop_listener(?LISTENER),
-             lists:map(fun(App) ->
-                               error_logger:tty(false),
-                               try application:stop(App)
-                               after error_logger:tty(true)
-                               end
-                       end, proplists:get_value(apps, Config))
+             lists:map(
+               fun(App) ->
+                       error_logger:tty(false),
+                       try
+                           application:stop(App)
+                       after
+                           error_logger:tty(true)
+                       end
+               end,
+               proplists:get_value(apps, Config)
+              )
      end,
      fun(Config) ->
              HostInfo = proplists:get_value(hostinfo, Config),
@@ -56,36 +68,44 @@ checkout_checkin_test_() ->
                        "initial checkout",
                        fun(Title) ->
                                %% checkout
-                               {ok, {await_up, {ReturnTo, Pid}}} = gen_server:call(?MODULE, {checkout, HostInfo}),
-                               Ret1 = receive
-                                          V1 -> V1
-                                      end,
-                               #{await_up_conns := AwaitUpConns1,
-                                 up_conns := UpConns1,
-                                 host_conns := HostConns1
-                                } = gen_server:call(?MODULE, dump_state),
+                               {ok, {await_up, {ReturnTo, Pid}}} = gen_server:call(
+                                                                     ?MODULE, {checkout, HostInfo}
+                                                                    ),
+                               Ret1 =
+                               receive
+                                   V1 -> V1
+                               end,
+                               State1 = gen_server:call(?MODULE, dump_state),
                                %% checkin
                                honey_pool:return_to(ReturnTo, Pid, {checkin, HostInfo, Pid}),
-                               #{await_up_conns := AwaitUpConns2,
-                                 up_conns := UpConns2,
-                                 host_conns := HostConns2
-                                } = gen_server:call(?MODULE, dump_state),
+                               State2 = gen_server:call(?MODULE, dump_state),
                                %% tests
                                [
-                                {Title++": receive",
-                                 ?_assertEqual({gun_up, Pid, http}, Ret1)},
-                                {Title++": up_conns is empty after checkout",
-                                 ?_assertMatch(#{}, UpConns1)},
-                                {Title++": await_up_conns is empty after checkout",
-                                 ?_assertMatch(#{}, AwaitUpConns1)},
-                                {Title++": host_conns is empty after checkout",
-                                 ?_assertMatch(#{}, HostConns1)},
-                                {Title++": up_conns has pid after checkin",
-                                 ?_assertMatch(#{Pid := HostInfo}, UpConns2)},
-                                {Title++": await_up_conns is empty after checkin",
-                                 ?_assertMatch(#{}, AwaitUpConns2)},
-                                {Title++": host_conns after checkin",
-                                 ?_assertMatch(#{HostInfo := [{Pid, _, _tref}]}, HostConns2)}
+                                {Title ++ ": receive", ?_assertEqual({gun_up, Pid, http}, Ret1)},
+                                {
+                                 Title ++ ": dump_state 1",
+                                 ?_assertEqual(
+                                    #{
+                                      await_up_conns => #{},
+                                      checked_in_conns => #{},
+                                      checked_out_conns => #{Pid => HostInfo},
+                                      pool_conns => #{}
+                                     },
+                                    State1
+                                   )
+                                },
+                                {
+                                 Title ++ ": dump_state 2",
+                                 ?_assertEqual(
+                                    #{
+                                      await_up_conns => #{},
+                                      checked_in_conns => #{Pid => HostInfo},
+                                      checked_out_conns => #{},
+                                      pool_conns => #{HostInfo => [Pid]}
+                                     },
+                                    State2
+                                   )
+                                }
                                ]
                        end
                       },
@@ -93,31 +113,39 @@ checkout_checkin_test_() ->
                        "second checkout",
                        fun(Title) ->
                                %% checkout
-                               {ok, {up, {ReturnTo, Pid}}} = gen_server:call(?MODULE, {checkout, HostInfo}),
-                               #{await_up_conns := AwaitUpConns1,
-                                 up_conns := UpConns1,
-                                 host_conns := HostConns1
-                                } = gen_server:call(?MODULE, dump_state),
+                               {ok, {up, {ReturnTo, Pid}}} = gen_server:call(
+                                                               ?MODULE, {checkout, HostInfo}
+                                                              ),
+                               State1 = gen_server:call(?MODULE, dump_state),
                                %% checkin
                                honey_pool:return_to(ReturnTo, Pid, {checkin, HostInfo, Pid}),
-                               #{await_up_conns := AwaitUpConns2,
-                                 up_conns := UpConns2,
-                                 host_conns := HostConns2
-                                } = gen_server:call(?MODULE, dump_state),
+                               State2 = gen_server:call(?MODULE, dump_state),
                                %% tests
                                [
-                                {Title++": up_conns is empty after checkout",
-                                 ?_assertMatch(#{}, UpConns1)},
-                                {Title++": await_up_conns is empty after checkout",
-                                 ?_assertMatch(#{}, AwaitUpConns1)},
-                                {Title++": host_conns is empty after checkout",
-                                 ?_assertMatch(#{}, HostConns1)},
-                                {Title++": up_conns has pid after checkin",
-                                 ?_assertMatch(#{Pid := HostInfo}, UpConns2)},
-                                {Title++": await_up_conns is empty after checkin",
-                                 ?_assertMatch(#{}, AwaitUpConns2)},
-                                {Title++": host_conns after checkin",
-                                 ?_assertMatch(#{HostInfo := [{Pid, _, _tref}]}, HostConns2)}
+                                {
+                                 Title ++ ": dump_state 1",
+                                 ?_assertEqual(
+                                    #{
+                                      await_up_conns => #{},
+                                      checked_in_conns => #{},
+                                      checked_out_conns => #{Pid => HostInfo},
+                                      pool_conns => #{}
+                                     },
+                                    State1
+                                   )
+                                },
+                                {
+                                 Title ++ ": dump_state 2",
+                                 ?_assertEqual(
+                                    #{
+                                      await_up_conns => #{},
+                                      checked_in_conns => #{Pid => HostInfo},
+                                      checked_out_conns => #{},
+                                      pool_conns => #{HostInfo => [Pid]}
+                                     },
+                                    State2
+                                   )
+                                }
                                ]
                        end
                       },
@@ -125,21 +153,26 @@ checkout_checkin_test_() ->
                        "sudden down",
                        fun(Title) ->
                                %% checkout
-                               {ok, {up, {_ReturnTo, Pid}}} = gen_server:call(?MODULE, {checkout, HostInfo}),
+                               {ok, {up, {_ReturnTo, Pid}}} = gen_server:call(
+                                                                ?MODULE, {checkout, HostInfo}
+                                                               ),
                                %% closing conn
                                gun:close(Pid),
-                               #{await_up_conns := AwaitUpConns,
-                                 up_conns := UpConns,
-                                 host_conns := HostConns
-                                } = gen_server:call(?MODULE, dump_state),
+                               State = gen_server:call(?MODULE, dump_state),
                                %% tests
                                [
-                                {Title++": up_conns is empty after down",
-                                 ?_assertMatch(#{}, UpConns)},
-                                {Title++": await_up_conns is empty after down",
-                                 ?_assertMatch(#{}, AwaitUpConns)},
-                                {Title++": host_conns is empty after down",
-                                 ?_assertMatch(#{}, HostConns)}
+                                {
+                                 Title ++ ": conn is cleaned",
+                                 ?_assertEqual(
+                                    #{
+                                      await_up_conns => #{},
+                                      checked_in_conns => #{},
+                                      checked_out_conns => #{},
+                                      pool_conns => #{}
+                                     },
+                                    State
+                                   )
+                                }
                                ]
                        end
                       },
@@ -147,36 +180,45 @@ checkout_checkin_test_() ->
                        "after idle_timeout (500 ms)",
                        fun(Title) ->
                                %% checkout
-                               {ok, {await_up, {ReturnTo, Pid}}} = gen_server:call(?MODULE, {checkout, HostInfo}),
-                               {gun_up, Pid, http} = receive
-                                                         V1 -> V1
-                                                     end,
+                               {ok, {await_up, {ReturnTo, Pid}}} = gen_server:call(
+                                                                     ?MODULE, {checkout, HostInfo}
+                                                                    ),
+                               {gun_up, Pid, http} =
+                               receive
+                                   V1 -> V1
+                               end,
                                %% checkin
                                honey_pool:return_to(ReturnTo, Pid, {checkin, HostInfo, Pid}),
-                               #{await_up_conns := AwaitUpConns1,
-                                 up_conns := UpConns1,
-                                 host_conns := HostConns1
-                                } = gen_server:call(?MODULE, dump_state),
+                               State1 = gen_server:call(?MODULE, dump_state),
                                %% idle_timeout (with extra 250 ms)
                                timer:sleep(750),
-                               #{await_up_conns := AwaitUpConns2,
-                                 up_conns := UpConns2,
-                                 host_conns := HostConns2
-                                } = gen_server:call(?MODULE, dump_state),
+                               State2 = gen_server:call(?MODULE, dump_state),
                                %% tests
                                [
-                                {Title++": up_conns has pid after checkin",
-                                 ?_assertMatch(#{Pid := HostInfo}, UpConns1)},
-                                {Title++": await_up_conns is empty after checkin",
-                                 ?_assertMatch(#{}, AwaitUpConns1)},
-                                {Title++": host_conns after checkin",
-                                 ?_assertMatch(#{HostInfo := [{Pid, _, _tref}]}, HostConns1)},
-                                {Title++": up_conns is empty after idle timeout",
-                                 ?_assertMatch(#{}, UpConns2)},
-                                {Title++": await_up_conns is empty after idle timeout",
-                                 ?_assertMatch(#{}, AwaitUpConns2)},
-                                {Title++": host_conns is empty after idle timeout",
-                                 ?_assertMatch(#{}, HostConns2)}
+                                {
+                                 Title ++ ": before idle timeout",
+                                 ?_assertEqual(
+                                    #{
+                                      await_up_conns => #{},
+                                      checked_in_conns => #{Pid => HostInfo},
+                                      checked_out_conns => #{},
+                                      pool_conns => #{HostInfo => [Pid]}
+                                     },
+                                    State1
+                                   )
+                                },
+                                {
+                                 Title ++ ": after idle timeout",
+                                 ?_assertEqual(
+                                    #{
+                                      await_up_conns => #{},
+                                      checked_in_conns => #{},
+                                      checked_out_conns => #{},
+                                      pool_conns => #{}
+                                     },
+                                    State2
+                                   )
+                                }
                                ]
                        end
                       }
@@ -186,3 +228,4 @@ checkout_checkin_test_() ->
                  end,
              lists:map(F, Cases)
      end}.
+


### PR DESCRIPTION
Let 1 worker handle a connection at all time.
This prevents `gun_down` message accidentally received by client process.