### PR TITLE
fix(connection): worker to start idle timer on await_up connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ test:
 	$(REBAR3) do eunit,xref,dialyzer
 
 format:
-	$(REBAR3) efmt -w -- src/** test/**
+	$(REBAR3) efmt -w -- src/** include/** test/**
 
 .PHONY: all test format

--- a/config/sys.config
+++ b/config/sys.config
@@ -5,6 +5,7 @@
           ]},
 
  {honey_pool, [{idle_timeout, 10000},
+               {await_up_timeout, 5000},
                {wpool, [{workers, 3}]}
               ]}
 ].

--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -10,7 +10,8 @@
 -record(state, {
           tabid :: ets:tid(),
           gun_opts = #{} :: gun_opts(),
-          idle_timeout = infinity :: timeout()
+          idle_timeout = infinity :: timeout(),
+          await_up_timeout = 5000 :: timeout()
          }).
 
 -type gun_opts() :: gun:opts().
@@ -20,6 +21,6 @@
 -type monitor_ref() :: reference().
 
 -type transport() :: tcp | tls.
--type hostinfo() :: {Host::string(), Port::integer(), Transport::transport()}.
+-type hostinfo() :: {Host :: string(), Port :: integer(), Transport :: transport()}.
 -type state() :: #state{}.
 -type uri() :: #uri{}.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -238,9 +238,7 @@ checkout(HostInfo, Timeout) ->
 
 -spec cancel_await_up(ReturnTo :: pid(), Conn :: conn()) -> ok.
 cancel_await_up(ReturnTo, {Pid, MRef}) ->
-    %% explicitly cancel the await_up request
     demonitor(MRef),
-    gun:close(Pid),
     return_to(ReturnTo, Pid, {cancel_await_up, Pid}).
 
 -spec checkin(ReturnTo :: pid(), HostInfo :: hostinfo(), Conn :: conn()) -> ok.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -239,6 +239,7 @@ checkout(HostInfo, Timeout) ->
 -spec cancel_await_up(ReturnTo :: pid(), Conn :: conn()) -> ok.
 cancel_await_up(ReturnTo, {Pid, MRef}) ->
     demonitor(MRef),
+    gun:close(Pid),
     return_to(ReturnTo, Pid, {cancel_await_up, Pid}).
 
 -spec checkin(ReturnTo :: pid(), HostInfo :: hostinfo(), Conn :: conn()) -> ok.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -238,6 +238,7 @@ checkout(HostInfo, Timeout) ->
 
 -spec cancel_await_up(ReturnTo :: pid(), Conn :: conn()) -> ok.
 cancel_await_up(ReturnTo, {Pid, MRef}) ->
+    %% explicitly cancel the await_up request
     demonitor(MRef),
     gun:close(Pid),
     return_to(ReturnTo, Pid, {cancel_await_up, Pid}).

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -238,7 +238,7 @@ checkout(HostInfo, Timeout) ->
 
 -spec cancel_await_up(ReturnTo :: pid(), Conn :: conn()) -> ok.
 cancel_await_up(ReturnTo, {Pid, MRef}) ->
-    demonitor(MRef),
+    demonitor(MRef, [flush]),
     return_to(ReturnTo, Pid, {cancel_await_up, Pid}).
 
 -spec checkin(ReturnTo :: pid(), HostInfo :: hostinfo(), Conn :: conn()) -> ok.

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -201,7 +201,10 @@ conn_cancel_await_up(Pid, #state{tabid = TabId, idle_timeout = IdleTimeout}) ->
             cancel_idle_timer(TRef),
             ets:insert(TabId,
                        {{pid, Pid},
-                        Conn#conn{requester = undefined, timer_ref = idle_timer(Pid, IdleTimeout)}}),
+                        Conn#conn{
+                          requester = undefined,
+                          timer_ref = idle_timer(Pid, IdleTimeout)
+                         }}),
             ok;
         _ ->
             ok
@@ -247,7 +250,8 @@ conn_up(Pid, Protocol, #state{tabid = TabId} = State) ->
                 Requester ->
                     %% notify requester and tag that conn is checked out
                     Requester ! {gun_up, Pid, Protocol},
-                    ets:insert(TabId, {{pid, Pid}, Conn#conn{state = checked_out, requester = undefined}}),
+                    ets:insert(TabId,
+                               {{pid, Pid}, Conn#conn{state = checked_out, requester = undefined}}),
                     {ok, {Conn#conn.hostinfo, Pid}}
             end;
         _ ->

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -43,7 +43,8 @@ init(Args) ->
      #state{
        tabid = ets:new(?ETS_TABLE, [set]),
        gun_opts = maps:merge(?DEFAULT_OPTS, proplists:get_value(gun_opts, Args, #{})),
-       idle_timeout = proplists:get_value(idle_timeout, Args, infinity)
+       idle_timeout = proplists:get_value(idle_timeout, Args, infinity),
+       await_up_timeout = proplists:get_value(await_up_timeout, Args, 5000)
       }}.
 
 
@@ -195,7 +196,7 @@ conn_open({Host, Port, Transport},
 
 
 -spec conn_cancel_await_up(Pid :: pid(), State :: state()) -> ok.
-conn_cancel_await_up(Pid, #state{tabid = TabId, idle_timeout = IdleTimeout}) ->
+conn_cancel_await_up(Pid, #state{tabid = TabId, await_up_timeout = AwaitUpTimeout}) ->
     case ets:lookup(TabId, {pid, Pid}) of
         [{_, Conn = #conn{timer_ref = TRef}}] ->
             cancel_idle_timer(TRef),
@@ -203,7 +204,7 @@ conn_cancel_await_up(Pid, #state{tabid = TabId, idle_timeout = IdleTimeout}) ->
                        {{pid, Pid},
                         Conn#conn{
                           requester = undefined,
-                          timer_ref = idle_timer(Pid, IdleTimeout)
+                          timer_ref = idle_timer(Pid, AwaitUpTimeout)
                          }}),
             ok;
         _ ->


### PR DESCRIPTION
once a client gives up on a connection in await_up state, a worker starts an idle timer on it so that connections won't stay in that state too long.