### PR TITLE
feat: Add stress test suite

### DIFF
--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -39,4 +39,3 @@
 
 %% @doc A parsed URI.
 -type uri() :: #uri{}.
-

--- a/src/honey_pool_app.erl
+++ b/src/honey_pool_app.erl
@@ -9,9 +9,11 @@
 
 -export([start/2, stop/1]).
 
+
 %% @doc Starts the honey_pool application.
 start(_StartType, _StartArgs) ->
     honey_pool_sup:start_link().
+
 
 %% @doc Stops the honey_pool application.
 stop(_State) ->

--- a/src/honey_pool_sup.erl
+++ b/src/honey_pool_sup.erl
@@ -13,6 +13,7 @@
 
 -define(SERVER, ?MODULE).
 
+
 %% @doc Starts the honey_pool supervisor.
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
@@ -37,12 +38,14 @@ init([]) ->
     IdleTimeout = application:get_env(honey_pool, idle_timeout, infinity),
     WpoolUserConfig = application:get_env(honey_pool, wpool, []),
     WpoolDefaultConfig =
-        #{workers => 2,
+        #{
+          workers => 2,
           overrun_warning => 300,
           worker =>
               {honey_pool_worker,
                [{gun_opts, GunOpts},
-                {idle_timeout, IdleTimeout}]}},
+                {idle_timeout, IdleTimeout}]}
+         },
     WpoolConfig =
         maps:to_list(
           maps:merge(WpoolDefaultConfig, maps:from_list(WpoolUserConfig))),

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -34,8 +34,8 @@
 -type requester() :: pid() | undefined.
 -type timer_ref() :: reference() | undefined.
 
-
 %% @doc Callback functions for the honey_pool_worker gen_server.
+
 
 %% @doc Initializes the honey_pool_worker.
 -spec init(Args :: list()) -> {ok, state()}.

--- a/test/honey_pool_stress_tests.erl
+++ b/test/honey_pool_stress_tests.erl
@@ -1,0 +1,104 @@
+-module(honey_pool_stress_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([init/2]).
+
+
+stress_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun run/1}.
+
+
+setup() ->
+    Apps =
+        lists:flatten(
+          lists:map(fun(App) ->
+                            {ok, Started} = application:ensure_all_started(App),
+                            Started
+                    end,
+                    [cowboy, honey_pool])),
+    Dispatch = cowboy_router:compile([{'_', [{"/", ?MODULE, []}]}]),
+    {ok, _} = cowboy:start_clear(?MODULE, [{port, 0}], #{env => #{dispatch => Dispatch}}),
+    #{
+      apps => Apps,
+      url => io_lib:format("http://localhost:~.10b", [ranch:get_port(?MODULE)])
+     }.
+
+
+cleanup(#{apps := Apps}) ->
+    error_logger:tty(false),
+    ok = cowboy:stop_listener(?MODULE),
+    try
+        lists:map(fun(App) -> application:stop(App) end, Apps)
+    after
+        error_logger:tty(true)
+    end,
+    ok.
+
+
+-define(CONCURRENCY,          100).
+-define(REQS_PER_CHILD,       100).
+-define(RESPONSE_STATUS_CODE, 200).
+-define(RESPONSE_DELAY,       20).
+-define(RESPONSE_BODY,        <<"Hello">>).
+
+
+run(#{url := Url}) ->
+    [{"a request",
+      fun() ->
+              Resp = honey_pool:get(Url, [], 200),
+              ?assertMatch({ok, {200, _, ?RESPONSE_BODY}}, Resp)
+      end},
+     {"many requests",
+      fun() ->
+              Parent = self(),
+              Result =
+                  lists:foldl(fun(#{ok := OkCount, error := ErrCount},
+                                  Acc = #{ok := OkTotal, error := ErrTotal}) ->
+                                      Acc#{ok => OkTotal + OkCount, error => ErrTotal + ErrCount}
+                              end,
+                              #{ok => 0, error => 0},
+                              collect_from_children(spawn_children(Parent, Url))),
+              ?assertEqual(#{ok => ?CONCURRENCY * ?REQS_PER_CHILD, error => 0}, Result)
+      end}].
+
+
+spawn_children(Parent, Url) ->
+    lists:map(fun(_) -> spawn_link(fun() -> run_child(Parent, Url, ?REQS_PER_CHILD) end) end,
+              lists:seq(1, ?CONCURRENCY)).
+
+
+run_child(Parent, Url, Count) ->
+    Result =
+        lists:foldl(fun(_, #{ok := OkCount, error := ErrCount} = Acc) ->
+                            case honey_pool:get(Url, [], 200) of
+                                {ok, {?RESPONSE_STATUS_CODE, _, _}} -> Acc#{ok => OkCount + 1};
+                                _ -> Acc#{error => ErrCount + 1}
+                            end
+                    end,
+                    #{ok => 0, error => 0},
+                    lists:seq(1, Count)),
+    Parent ! {self(), Result},
+    ok.
+
+
+collect_from_children(Workers) ->
+    collect_from_children(Workers, []).
+
+
+collect_from_children([], Results) ->
+    Results;
+collect_from_children(Workers, Results) ->
+    receive
+        {Child, Result} ->
+            collect_from_children(lists:delete(Child, Workers), [Result | Results])
+    end.
+
+
+init(Req0, State) ->
+    timer:sleep(?RESPONSE_DELAY),
+    Req = cowboy_req:reply(?RESPONSE_STATUS_CODE,
+                           #{<<"content-type">> => <<"text/plain">>},
+                           ?RESPONSE_BODY,
+                           Req0),
+    {ok, Req, State}.

--- a/test/honey_pool_stress_tests.erl
+++ b/test/honey_pool_stress_tests.erl
@@ -101,6 +101,7 @@ collect_from_children(Workers, Results) ->
 
 
 init(Req0, State) ->
+    rand:seed({os:timestamp(), self()}),  % Seed the random number generator for true randomness
     Delay = rand:uniform(?RESPONSE_MAX_DELAY),  % Random delay to simulate variability
     timer:sleep(Delay),
     Req = cowboy_req:reply(?RESPONSE_STATUS_CODE,

--- a/test/honey_pool_stress_tests.erl
+++ b/test/honey_pool_stress_tests.erl
@@ -94,7 +94,7 @@ collect_from_children(Workers, Results) ->
         {Child, Result} ->
             collect_from_children(lists:delete(Child, Workers), [Result | Results])
     after
-        5000 ->
+        ?CHILD_TIMEOUT ->
             ?LOG_ERROR("Timeout waiting for child processes to finish"),
             []
     end.

--- a/test/honey_pool_stress_tests.erl
+++ b/test/honey_pool_stress_tests.erl
@@ -39,6 +39,7 @@ cleanup(#{apps := Apps}) ->
 
 -define(CONCURRENCY,          100).
 -define(REQS_PER_CHILD,       100).
+-define(CHILD_TIMEOUT,        5000).  % Timeout for child processes to finish
 -define(RESPONSE_STATUS_CODE, 200).
 -define(RESPONSE_MAX_DELAY,   20).
 -define(RESPONSE_BODY,        <<"Hello">>).
@@ -101,7 +102,6 @@ collect_from_children(Workers, Results) ->
 
 
 init(Req0, State) ->
-    rand:seed({os:timestamp(), self()}),  % Seed the random number generator for true randomness
     Delay = rand:uniform(?RESPONSE_MAX_DELAY),  % Random delay to simulate variability
     timer:sleep(Delay),
     Req = cowboy_req:reply(?RESPONSE_STATUS_CODE,

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -9,123 +9,83 @@ init(Req0, State) ->
     StatusCode = binary_to_integer(cowboy_req:binding(status_code, Req0)),
     Delay = binary_to_integer(cowboy_req:binding(delay_millisec, Req0)),
     timer:sleep(Delay),
-    Req = cowboy_req:reply(
-            StatusCode,
-            #{<<"content-type">> => <<"text/plain">>},
-            <<"Hello">>,
-            Req0),
+    Req = cowboy_req:reply(StatusCode,
+                           #{<<"content-type">> => <<"text/plain">>},
+                           <<"Hello">>,
+                           Req0),
     {ok, Req, State}.
 
 
 request_test_() ->
     {setup,
      fun() ->
-             Apps = lists:flatten(
-                      lists:map(
-                        fun(App) ->
-                                {ok, Started} = application:ensure_all_started(App),
-                                Started
-                        end,
-                        [cowboy, honey_pool])),
-             Dispatch = cowboy_router:compile(
-                          [{'_', [{"/status/:status_code/delay/:delay_millisec", ?MODULE, []}]}]),
-             {ok, _} = cowboy:start_clear(
-                         ?MODULE,
-                         [{port, 0}],
-                         #{env => #{dispatch => Dispatch}}),
-             #{
-               apps => Apps,
-               url => io_lib:format(
-                        "http://localhost:~.10b",
-                        [ranch:get_port(?MODULE)])
-              }
+             Apps =
+                 lists:flatten(
+                   lists:map(fun(App) ->
+                                     {ok, Started} = application:ensure_all_started(App),
+                                     Started
+                             end,
+                             [cowboy, honey_pool])),
+             Dispatch =
+                 cowboy_router:compile([{'_',
+                                         [{"/status/:status_code/delay/:delay_millisec",
+                                           ?MODULE,
+                                           []}]}]),
+             {ok, _} = cowboy:start_clear(?MODULE, [{port, 0}], #{env => #{dispatch => Dispatch}}),
+             #{apps => Apps, url => io_lib:format("http://localhost:~.10b", [ranch:get_port(?MODULE)])}
      end,
      fun(#{apps := Apps}) ->
              error_logger:tty(false),
              ok = cowboy:stop_listener(?MODULE),
              try
-                 lists:map(
-                   fun(App) ->
-                           application:stop(App)
-                   end,
-                   Apps)
+                 lists:map(fun(App) -> application:stop(App) end, Apps)
              after
                  error_logger:tty(true)
              end,
              ok
      end,
      fun(#{url := Url}) ->
-             Cases = [{"get: not found",
-                       fun() ->
-                               Actual = honey_pool:get([Url, "/foobar"]),
-                               ?assertMatch(
-                                 {ok, {404, _, _}},
-                                 Actual)
-                       end},
-                      {"get: timeout=infinity",
-                       fun() ->
-                               Actual = honey_pool:get(
-                                          [Url, "/status/200/delay/500"],
-                                          [],
-                                          infinity),
-                               ?assertMatch(
-                                 {ok, {200, _, _}},
-                                 Actual)
-                       end},
-                      {"get: with query",
-                       fun() ->
-                               Actual = honey_pool:get(
-                                          [Url, "/status/200/delay/50?foo=${FOO}&bar=][&buz=.."],
-                                          [],
-                                          infinity),
-                               ?assertMatch(
-                                 {ok, {200, _, _}},
-                                 Actual)
-                       end},
-                      {"get: delay < timeout",
-                       fun() ->
-                               Actual = honey_pool:get(
-                                          [Url, "/status/200/delay/50"],
-                                          [],
-                                          1000),
-                               ?assertMatch(
-                                 {ok, {200, _, _}},
-                                 Actual)
-                       end},
-                      {"get: delay > timeout",
-                       fun() ->
-                               Actual = honey_pool:get(
-                                          [Url, "/status/200/delay/100"],
-                                          [],
-                                          5),
-                               ?assertMatch(
-                                 {error, {timeout, await}},
-                                 Actual)
-                       end},
-                      {"post: timeout=infinity",
-                       fun() ->
-                               Actual = honey_pool:post(
-                                          [Url, "/status/200/delay/500"],
-                                          [],
-                                          <<"req data">>,
-                                          infinity),
-                               ?assertMatch(
-                                 {ok, {200, _, _}},
-                                 Actual)
-                       end},
-                      {"get: status=400",
-                       fun() ->
-                               Actual = honey_pool:post(
-                                          [Url, "/status/400/delay/50"],
-                                          [],
-                                          <<"req data">>,
-                                          infinity),
-                               ?assertMatch(
-                                 {ok, {400, _, no_data}},
-                                 Actual)
-                       end}],
-             F = fun({Title, Test}) ->
-                         [{Title, Test}]
-                 end,
+             Cases =
+                 [{"get: not found",
+                   fun() ->
+                           Actual = honey_pool:get([Url, "/foobar"]),
+                           ?assertMatch({ok, {404, _, _}}, Actual)
+                   end},
+                  {"get: timeout=infinity",
+                   fun() ->
+                           Actual = honey_pool:get([Url, "/status/200/delay/500"], [], infinity),
+                           ?assertMatch({ok, {200, _, _}}, Actual)
+                   end},
+                  {"get: with query",
+                   fun() ->
+                           Actual =
+                               honey_pool:get([Url, "/status/200/delay/50?foo=${FOO}&bar=][&buz=.."],
+                                              [],
+                                              infinity),
+                           ?assertMatch({ok, {200, _, _}}, Actual)
+                   end},
+                  {"get: delay < timeout",
+                   fun() ->
+                           Actual = honey_pool:get([Url, "/status/200/delay/50"], [], 1000),
+                           ?assertMatch({ok, {200, _, _}}, Actual)
+                   end},
+                  {"get: delay > timeout",
+                   fun() ->
+                           Actual = honey_pool:get([Url, "/status/200/delay/100"], [], 5),
+                           ?assertMatch({error, {timeout, await}}, Actual)
+                   end},
+                  {"post: timeout=infinity",
+                   fun() ->
+                           Actual =
+                               honey_pool:post([Url, "/status/200/delay/500"], [], <<"req data">>, infinity),
+                           ?assertMatch({ok, {200, _, _}}, Actual)
+                   end},
+                  {"get: status=400",
+                   fun() ->
+                           Actual =
+                               honey_pool:post([Url, "/status/400/delay/50"], [], <<"req data">>, infinity),
+                           ?assertMatch({ok, {400, _, no_data}}, Actual)
+                   end}],
+             F = fun({Title, Test}) -> [{Title, Test}] end,
              lists:map(F, Cases)
      end}.


### PR DESCRIPTION
This PR introduces a comprehensive stress test suite to validate the honey_pool library's performance and stability under concurrent load. This is a critical step towards a Beta release.

Key features of this test suite include:
- Concurrent execution of multiple workers.
- Randomized delays in the mock server to simulate real-world network variability.
- Robust handling of child process results with timeouts to prevent test hangs.

This work directly addresses the "Concurrency and Stress Testing" item identified for the Beta release.