### PR TITLE
docs: Improve code documentation

### DIFF
--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -1,37 +1,37 @@
 %% @doc Represents a parsed URI.
 -record(uri, {
-          host = "" :: string(),
-          path = "" :: string(),
-          query = "" :: string(),
-          pathquery = "" :: string(),
-          port = 80 :: integer(),
-          transport = tcp :: transport()
+          host = "" :: string(), %% The host part of the URI.
+          path = "" :: string(), %% The path part of the URI.
+          query = "" :: string(), %% The query string part of the URI.
+          pathquery = "" :: string(), %% The path and query string combined.
+          port = 80 :: integer(), %% The port number of the URI.
+          transport = tcp :: transport() %% The transport protocol (tcp or tls).
          }).
 
 %% @doc Represents the state of a honey_pool_worker.
 -record(state, {
-          tabid :: ets:tid(),
-          gun_opts = #{} :: gun_opts(),
-          idle_timeout = infinity :: timeout(),
-          await_up_timeout = 5000 :: timeout()
+          tabid :: ets:tid(), %% The ETS table ID for storing connection data.
+          gun_opts = #{} :: gun_opts(), %% Default options for gun connections.
+          idle_timeout = infinity :: timeout(), %% Timeout for idle connections.
+          await_up_timeout = 5000 :: timeout() %% Timeout for waiting for a connection to be established.
          }).
 
-%% @doc Gun options.
+%% @doc Gun options for connection settings.
 -type gun_opts() :: gun:opts().
 
 %% @doc Gun request options.
 -type gun_req_opts() :: gun:req_opts().
 
-%% @doc A gun connection.
+%% @doc A gun connection, represented by its process ID and a monitor reference.
 -type conn() :: {pid(), monitor_ref()}.
 
-%% @doc A monitor reference.
+%% @doc A monitor reference for a process.
 -type monitor_ref() :: reference().
 
-%% @doc The transport protocol.
+%% @doc The transport protocol for the connection.
 -type transport() :: tcp | tls.
 
-%% @doc Information about a host.
+%% @doc Information about a host, including host, port, and transport protocol.
 -type hostinfo() :: {Host :: string(), Port :: integer(), Transport :: transport()}.
 
 %% @doc The state of a honey_pool_worker.

--- a/src/honey_pool_uri.erl
+++ b/src/honey_pool_uri.erl
@@ -5,7 +5,10 @@
 -include("honey_pool.hrl").
 
 
-%% @doc Parses a URL string into a uri record.
+%% @doc Parses a URL string into a `uri` record.
+%% It handles both binary and string inputs, separates the query string,
+%% and uses `uri_string:parse` for the main parsing logic.
+%% It determines the transport protocol (tcp/tls) and sets default ports if not specified.
 -spec parse(string() | binary()) -> {ok, uri()} | {error, term()}.
 parse(Uri) when is_binary(Uri) ->
     parse(binary_to_list(Uri));


### PR DESCRIPTION
Add detailed comments and edoc annotations to improve code readability and maintainability.

- Add detailed comments to records and type definitions in `honey_pool.hrl`.
- Add edoc annotations to public and private functions in `honey_pool.erl`.
- Add edoc annotations to gen_server callbacks and private functions in `honey_pool_worker.erl`.
- Improve the edoc annotation for the `parse/1` function in `honey_pool_uri.erl`.
