### PR TITLE
Fix: Correct and simplify the `resp()` type definition

### DIFF
--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -20,8 +20,8 @@
 -type req_headers() :: gun:req_headers().
 -type resp() ::
         {ok, {status(), resp_headers(), binary() | no_data}} |
-        {timeout, await_body | await | checkout | await_up} |
-        {error, {uri, term()} |
+        {error, {timeout, term()} |
+                {uri, term()} |
                 {checkout, term()} |
                 {await_body, term()} |
                 {await, term()} |

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -20,13 +20,13 @@
 -type req_headers() :: gun:req_headers().
 -type resp() ::
         {ok, {status(), resp_headers(), binary() | no_data}} |
-        {error, {timeout, term()} |
-                {uri, term()} |
-                {checkout, term()} |
-                {await_body, term()} |
-                {await, term()} |
-                {pool_checkout, term()} |
-                {await_up, term()}}.
+        {error,
+         {await, term()} |
+         {await_body, term()} |
+         {checkout,
+          {timeout, term()} | {await_up, term()} | {pool_checkout, term()} | {checkout, term()}} |
+         {uri, term()} |
+         {timeout, term()}}.
 -type resp_headers() :: [{binary(), binary()}].
 -type status() :: integer().
 -type url() :: string().


### PR DESCRIPTION
This pull request addresses an issue where the `resp()` type in `honey_pool.erl` was both incorrect and difficult to read. The updated type now accurately reflects all possible error tuples and is structured in a more logical way.