### PR TITLE
docs: update connection limit configs in README and hrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Configure `honey_pool` in your `sys.config` file:
               %% honey_pool configurations
               {idle_timeout, 60000},    %% Close connection after 60 seconds of idle time.
               {await_up_timeout, 5000}, %% Max. time (in milliseconds) to wait for a newly opened connection to become available.
+              {max_conns, 100},          %% Max number of connections per worker.
+              {max_pending_conns, 10},   %% Max number of pending connections per worker.
 
               %% worker_pool configurations (see worker_pool documentation for details)
               {wpool, [

--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -14,8 +14,8 @@
           gun_opts = #{} :: gun_opts(),  %% Default options for gun connections.
           idle_timeout = infinity :: timeout(),  %% Timeout for idle connections.
           await_up_timeout = 5000 :: timeout(),  %% Timeout for waiting for a connection to be established.
-          max_conns = infinity :: non_neg_integer() | infinity,  %% Maximum number of total connections.
-          max_pending_conns = infinity :: non_neg_integer() | infinity,  %% Maximum number of pending (await_up) connections.
+          max_conns = infinity :: non_neg_integer() | infinity,  %% Maximum number of connections per worker.
+          max_pending_conns = infinity :: non_neg_integer() | infinity,  %% Maximum number of pending (await_up) connections per worker.
           cur_conns = 0 :: non_neg_integer(),  %% Current number of total connections.
           cur_pending_conns = 0 :: non_neg_integer()  %% Current number of pending connections.
          }).


### PR DESCRIPTION
Yo! Added the new `max_conns` and `max_pending_conns` configurations to the `README.md` and updated the comments in `include/honey_pool.hrl` to clarify that these limits are applied on a **per-worker** basis. 🍯🐝