### PR TITLE
feat: support connection-specific options and pooling

### DIFF
--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -35,8 +35,8 @@
 %% @doc The transport protocol for the connection.
 -type transport() :: tcp | tls.
 
-%% @doc Information about a host, including host, port, and transport protocol.
--type hostinfo() :: {Host :: string(), Port :: integer(), Transport :: transport()}.
+%% @doc Information about a host, including host, port, transport protocol, and connection options.
+-type hostinfo() :: {Host :: string(), Port :: integer(), Transport :: transport(), ConnOpts :: gun_opts()}.
 
 %% @doc The state of a honey_pool_worker.
 -type state() :: #state{}.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -193,6 +193,8 @@ do_request({Pid, MRef}, Method, Path, Headers, Body, Opts, Timeout) ->
                 case gun:await_body(Pid, StreamRef, TimeoutRemaining, MRef) of
                     {ok, RespBody} ->
                         {ok, {200, RespHeaders, RespBody}};
+                    {ok, RespBody, RespHeaders2} ->
+                        {ok, {200, lists:merge(RespHeaders2, RespHeaders), RespBody}};
                     {error, timeout} ->
                         {error, {timeout, await_body}};
                     {error, Reason} ->

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -117,7 +117,9 @@ post(Url, Headers, Body, Opts, Timeout) ->
 request(Method, Url, Headers, Body, Opts, Timeout) ->
     case honey_pool_uri:parse(Url) of
         {ok, U} ->
-            HostInfo = {U#uri.host, U#uri.port, U#uri.transport},
+            ConnOpts = maps:get(conn_opts, Opts, #{}),
+            ReqOpts = maps:get(req_opts, Opts, #{}),
+            HostInfo = {U#uri.host, U#uri.port, U#uri.transport, ConnOpts},
             {Elapsed, Checkout} = timer:tc(fun checkout/2, [HostInfo, Timeout]),
             case Checkout of
                 {ok, {ReturnTo, Conn}} ->
@@ -127,7 +129,7 @@ request(Method, Url, Headers, Body, Opts, Timeout) ->
                                    U#uri.pathquery,
                                    Headers,
                                    Body,
-                                   Opts,
+                                   ReqOpts,
                                    next_timeout(Timeout, Elapsed)),
                     handle_request_result(Result, ReturnTo, HostInfo, Conn, Method, Url);
                 {error, Reason} ->

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -34,6 +34,10 @@
 -type resp_headers() :: [{binary(), binary()}].
 -type status() :: integer().
 -type url() :: string().
+-type pool_opts() :: #{
+        conn_opts => gun_opts(),
+        req_opts => gun_req_opts()
+       }.
 
 
 %% @doc Performs a GET request.
@@ -51,7 +55,7 @@ get(Url, Timeout) ->
 
 
 %% @doc Performs a GET request with the given headers, options and timeout.
--spec get(Url :: url(), Headers :: req_headers(), Opts :: gun_req_opts() | timeout()) ->
+-spec get(Url :: url(), Headers :: req_headers(), Opts :: pool_opts() | timeout()) ->
           resp().
 get(Url, Headers, Opts) when is_map(Opts) ->
     get(Url, Headers, Opts, infinity);
@@ -62,7 +66,7 @@ get(Url, Headers, Timeout) ->
 %% @doc Performs a GET request with the given headers, options, and timeout.
 -spec get(Url :: url(),
           Headers :: req_headers(),
-          Opts :: gun_req_opts(),
+          Opts :: pool_opts(),
           Timeout :: timeout()) ->
           resp().
 get(Url, Headers, Opts, Timeout) ->
@@ -85,7 +89,7 @@ post(Url, Headers, Body) ->
 -spec post(Url :: url(),
            Headers :: req_headers(),
            Body :: binary(),
-           Opts :: gun_req_opts() | timeout()) ->
+           Opts :: pool_opts() | timeout()) ->
           resp().
 post(Url, Headers, Body, Opts) when is_map(Opts) ->
     post(Url, Headers, Body, Opts, infinity);
@@ -97,7 +101,7 @@ post(Url, Headers, Body, Timeout) ->
 -spec post(Url :: url(),
            Headers :: req_headers(),
            Body :: binary(),
-           Opts :: gun_req_opts(),
+           Opts :: pool_opts(),
            Timeout :: timeout()) ->
           resp().
 post(Url, Headers, Body, Opts, Timeout) ->
@@ -111,7 +115,7 @@ post(Url, Headers, Body, Opts, Timeout) ->
               Url :: url(),
               Headers :: req_headers(),
               Body :: binary() | no_data,
-              Opts :: gun_req_opts(),
+              Opts :: pool_opts(),
               Timeout :: timeout()) ->
           resp().
 request(Method, Url, Headers, Body, Opts, Timeout) ->

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -38,6 +38,8 @@
         conn_opts => gun_opts(),
         req_opts => gun_req_opts()
        }.
+%% Legacy format: a plain gun:req_opts() map without pool_opts() keys.
+-type legacy_req_opts() :: gun_req_opts().
 
 
 %% @doc Performs a GET request.
@@ -55,7 +57,9 @@ get(Url, Timeout) ->
 
 
 %% @doc Performs a GET request with the given headers, options and timeout.
--spec get(Url :: url(), Headers :: req_headers(), Opts :: pool_opts() | timeout()) ->
+-spec get(Url :: url(),
+          Headers :: req_headers(),
+          Opts :: pool_opts() | legacy_req_opts() | timeout()) ->
           resp().
 get(Url, Headers, Opts) when is_map(Opts) ->
     get(Url, Headers, Opts, infinity);
@@ -66,7 +70,7 @@ get(Url, Headers, Timeout) ->
 %% @doc Performs a GET request with the given headers, options, and timeout.
 -spec get(Url :: url(),
           Headers :: req_headers(),
-          Opts :: pool_opts(),
+          Opts :: pool_opts() | legacy_req_opts(),
           Timeout :: timeout()) ->
           resp().
 get(Url, Headers, Opts, Timeout) ->
@@ -89,7 +93,7 @@ post(Url, Headers, Body) ->
 -spec post(Url :: url(),
            Headers :: req_headers(),
            Body :: binary(),
-           Opts :: pool_opts() | timeout()) ->
+           Opts :: pool_opts() | legacy_req_opts() | timeout()) ->
           resp().
 post(Url, Headers, Body, Opts) when is_map(Opts) ->
     post(Url, Headers, Body, Opts, infinity);
@@ -101,7 +105,7 @@ post(Url, Headers, Body, Timeout) ->
 -spec post(Url :: url(),
            Headers :: req_headers(),
            Body :: binary(),
-           Opts :: pool_opts(),
+           Opts :: pool_opts() | legacy_req_opts(),
            Timeout :: timeout()) ->
           resp().
 post(Url, Headers, Body, Opts, Timeout) ->
@@ -115,14 +119,15 @@ post(Url, Headers, Body, Opts, Timeout) ->
               Url :: url(),
               Headers :: req_headers(),
               Body :: binary() | no_data,
-              Opts :: pool_opts(),
+              Opts :: pool_opts() | legacy_req_opts(),
               Timeout :: timeout()) ->
           resp().
 request(Method, Url, Headers, Body, Opts, Timeout) ->
     case honey_pool_uri:parse(Url) of
         {ok, U} ->
-            ConnOpts = maps:get(conn_opts, Opts, #{}),
-            ReqOpts = maps:get(req_opts, Opts, #{}),
+            NormalizedOpts = normalize_pool_opts(Opts),
+            ConnOpts = maps:get(conn_opts, NormalizedOpts, #{}),
+            ReqOpts = maps:get(req_opts, NormalizedOpts, #{}),
             HostInfo = {U#uri.host, U#uri.port, U#uri.transport, ConnOpts},
             {Elapsed, Checkout} = timer:tc(fun checkout/2, [HostInfo, Timeout]),
             case Checkout of
@@ -237,6 +242,20 @@ next_timeout(Timeout, MicroSec) ->
             Timeout - Interval;
         _ ->
             0
+    end.
+
+
+%% @private
+%% @doc Normalizes options to pool_opts() format.
+%% Supports both the new pool_opts() format (with 'conn_opts'/'req_opts' keys) and
+%% the legacy gun:req_opts() map format. A map that does not contain either
+%% 'conn_opts' or 'req_opts' key is treated as a legacy gun:req_opts() value and
+%% is wrapped as #{req_opts => Opts}, preserving backward compatibility.
+-spec normalize_pool_opts(Opts :: pool_opts() | legacy_req_opts()) -> pool_opts().
+normalize_pool_opts(Opts) when is_map(Opts) ->
+    case maps:is_key(conn_opts, Opts) orelse maps:is_key(req_opts, Opts) of
+        true  -> Opts;
+        false -> #{req_opts => Opts}
     end.
 
 

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -127,7 +127,9 @@ request(Method, Url, Headers, Body, Opts, Timeout) ->
         {ok, U} ->
             NormalizedOpts = normalize_pool_opts(Opts),
             ConnOpts = maps:get(conn_opts, NormalizedOpts, #{}),
-            ReqOpts = maps:get(req_opts, NormalizedOpts, #{}),
+            ReqOpts0 = maps:get(req_opts, NormalizedOpts, #{}),
+            LegacyReqOpts = maps:without([conn_opts, req_opts], NormalizedOpts),
+            ReqOpts = maps:merge(LegacyReqOpts, ReqOpts0),
             HostInfo = {U#uri.host, U#uri.port, U#uri.transport, ConnOpts},
             {Elapsed, Checkout} = timer:tc(fun checkout/2, [HostInfo, Timeout]),
             case Checkout of

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -41,6 +41,7 @@
 %% Legacy format: a plain gun:req_opts() map without pool_opts() keys.
 -type legacy_req_opts() :: gun_req_opts().
 
+-export_type([pool_opts/0]).
 
 %% @doc Performs a GET request.
 -spec get(Url :: url()) -> resp().

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -222,16 +222,17 @@ conn_open(_HostInfo, _Requester, #state{max_conns = Max, cur_conns = Cur} = Stat
 conn_open(_HostInfo, _Requester, #state{max_pending_conns = Max, cur_pending_conns = Cur} = State)
   when Cur >= Max ->
     {{error, {limit, max_pending_conns}}, State};
-conn_open({Host, Port, Transport},
+conn_open({Host, Port, Transport, ConnOpts},
           Requester,
           #state{
-            gun_opts = GunOpts,
+            gun_opts = DefaultGunOpts,
             tabid = TabId,
             cur_conns = CurConns,
             cur_pending_conns = CurPending
            } = State) ->
-    GunOptsWithTransport = GunOpts#{transport => Transport},
-    HostInfo = {Host, Port, Transport},
+    MergedGunOpts = maps:merge(DefaultGunOpts, ConnOpts),
+    GunOptsWithTransport = MergedGunOpts#{transport => Transport},
+    HostInfo = {Host, Port, Transport, ConnOpts},
     case gun:open(Host, Port, GunOptsWithTransport) of
         {ok, Pid} ->
             ets:insert(TabId,

--- a/test/honey_pool_edge_tests.erl
+++ b/test/honey_pool_edge_tests.erl
@@ -22,7 +22,7 @@ edge_test_() ->
                
                %% Start worker
                {ok, Pid} = gen_server:start_link(honey_pool_worker, [], []),
-               HostInfo = {"localhost", 1234, tcp},
+               HostInfo = {"localhost", 1234, tcp, #{}},
 
                %% Spawn a dummy process to act as a connection
                DummyConn = spawn(fun() -> receive _ -> ok end end),

--- a/test/honey_pool_limit_tests.erl
+++ b/test/honey_pool_limit_tests.erl
@@ -28,7 +28,7 @@ boot_server() ->
     Port = ranch:get_port(?LISTENER),
     [{apps, Apps},
      {port, Port},
-     {hostinfo, {"localhost", Port, tcp}}].
+     {hostinfo, {"localhost", Port, tcp, #{}}}].
 
 
 limit_test_() ->

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -93,13 +93,27 @@ request_test_() ->
                            ?assertMatch({error, {checkout, {timeout, await_up}}}, Actual)
                    end},
                   {"get: with http2 prior knowledge",
-                   fun() ->
-                           %% This won't actually succeed because our cowboy test listener
-                           %% is not configured for http2, but we can verify that the
-                           %% protocols option is handled and a connection attempt is made.
-                           Actual = honey_pool:get([Url, "/status/200/delay/10"], [], #{conn_opts => #{protocols => [http2]}}, 1000),
-                           ?assertMatch({ok, {200, _, _}}, Actual)
-                   end}],
+                  fun() ->
+                          %% This won't actually succeed because our cowboy test listener
+                          %% is not configured for http2, but we can verify that the
+                          %% protocols option is handled and a connection attempt is made.
+                          ConnOpts1 = #{conn_opts => #{protocols => [http2]}},
+                          ConnOpts2 = #{conn_opts => #{protocols => [http2], alt => true}},
+                          Actual1 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts1, 1000),
+                          ?assertMatch({ok, {200, _, _}}, Actual1),
+                          Actual2 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts2, 1000),
+                          ?assertMatch({ok, {200, _, _}}, Actual2),
+                          %% Verify that different conn_opts values are pooled separately
+                          State = honey_pool:dump_state(),
+                          case State of
+                              L when is_list(L) ->
+                                  ?assert(length(L) >= 2);
+                              M when is_map(M) ->
+                                  ?assert(maps:size(M) >= 2);
+                              _ ->
+                                  ?assert(false)
+                          end
+                  end}],
              F = fun({Title, Test}) -> [{Title, Test}] end,
              lists:map(F, Cases)
      end}.

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -94,6 +94,15 @@ request_test_() ->
                            Actual = honey_pool:get(HttpsUrl, [], 10),
                            ?assertMatch({error, {checkout, {timeout, await_up}}}, Actual)
                    end},
+                  {"get: with legacy req_opts map (backward compat)",
+                   fun() ->
+                           %% A plain gun:req_opts() map (no conn_opts/req_opts keys) should
+                           %% be treated as legacy request opts rather than silently ignored.
+                           %% reply_to => self() is a valid gun req_opt and should be forwarded.
+                           LegacyOpts = #{reply_to => self()},
+                           Actual = honey_pool:get([Url, "/status/200/delay/50"], [], LegacyOpts, 1000),
+                           ?assertMatch({ok, {200, _, _}}, Actual)
+                   end},
                   {"get: with http2 prior knowledge",
                    fun() ->
                            %% This won't actually succeed because our cowboy test listener

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -91,6 +91,14 @@ request_test_() ->
                            HttpsUrl = string:replace(Url, "http", "https", leading),
                            Actual = honey_pool:get(HttpsUrl, [], 10),
                            ?assertMatch({error, {checkout, {timeout, await_up}}}, Actual)
+                   end},
+                  {"get: with http2 prior knowledge",
+                   fun() ->
+                           %% This won't actually succeed because our cowboy test listener
+                           %% is not configured for http2, but we can verify that the
+                           %% protocols option is handled and a connection attempt is made.
+                           Actual = honey_pool:get([Url, "/status/200/delay/10"], [], #{conn_opts => #{protocols => [http2]}}, 1000),
+                           ?assertMatch({ok, {200, _, _}}, Actual)
                    end}],
              F = fun({Title, Test}) -> [{Title, Test}] end,
              lists:map(F, Cases)

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -105,19 +105,20 @@ request_test_() ->
                    end},
                   {"get: with http2 prior knowledge",
                    fun() ->
-                           %% This won't actually succeed because our cowboy test listener
-                           %% is not configured for http2, but we can verify that the
-                           %% protocols option is handled and a connection attempt is made.
-                           ConnOpts1 = #{conn_opts => #{protocols => [http2], retry => 0}},
-                           ConnOpts2 = #{conn_opts => #{protocols => [http2], retry => 1}},
+                           %% Our cowboy test listener is configured with start_clear/3 (HTTP/1),
+                           %% so we include an HTTP/1 fallback alongside http2. This verifies
+                           %% that the protocols option is handled and that different conn_opts
+                           %% values result in separate pooled connections.
+                           ConnOpts1 = #{conn_opts => #{protocols => [http2, http], retry => 0}},
+                           ConnOpts2 = #{conn_opts => #{protocols => [http2, http], retry => 1}},
                            Actual1 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts1, 1000),
                            ?assertMatch({ok, {200, _, _}}, Actual1),
                            Actual2 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts2, 1000),
                            ?assertMatch({ok, {200, _, _}}, Actual2),
                            %% Verify that different conn_opts values are pooled separately
                            {ok, #uri{port = Port}} = honey_pool_uri:parse(Url),
-                           Key1 = {"localhost", Port, tcp, #{protocols => [http2], retry => 0}},
-                           Key2 = {"localhost", Port, tcp, #{protocols => [http2], retry => 1}},
+                           Key1 = {"localhost", Port, tcp, #{protocols => [http2, http], retry => 0}},
+                           Key2 = {"localhost", Port, tcp, #{protocols => [http2, http], retry => 1}},
                            States = honey_pool:dump_state(),
                            CountConns =
                                fun(Key, SList) ->

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -4,6 +4,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-include("honey_pool.hrl").
+
 
 init(Req0, State) ->
     StatusCode = binary_to_integer(cowboy_req:binding(status_code, Req0)),
@@ -93,27 +95,31 @@ request_test_() ->
                            ?assertMatch({error, {checkout, {timeout, await_up}}}, Actual)
                    end},
                   {"get: with http2 prior knowledge",
-                  fun() ->
-                          %% This won't actually succeed because our cowboy test listener
-                          %% is not configured for http2, but we can verify that the
-                          %% protocols option is handled and a connection attempt is made.
-                          ConnOpts1 = #{conn_opts => #{protocols => [http2]}},
-                          ConnOpts2 = #{conn_opts => #{protocols => [http2], alt => true}},
-                          Actual1 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts1, 1000),
-                          ?assertMatch({ok, {200, _, _}}, Actual1),
-                          Actual2 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts2, 1000),
-                          ?assertMatch({ok, {200, _, _}}, Actual2),
-                          %% Verify that different conn_opts values are pooled separately
-                          State = honey_pool:dump_state(),
-                          case State of
-                              L when is_list(L) ->
-                                  ?assert(length(L) >= 2);
-                              M when is_map(M) ->
-                                  ?assert(maps:size(M) >= 2);
-                              _ ->
-                                  ?assert(false)
-                          end
-                  end}],
+                   fun() ->
+                           %% This won't actually succeed because our cowboy test listener
+                           %% is not configured for http2, but we can verify that the
+                           %% protocols option is handled and a connection attempt is made.
+                           ConnOpts1 = #{conn_opts => #{protocols => [http2], retry => 0}},
+                           ConnOpts2 = #{conn_opts => #{protocols => [http2], retry => 1}},
+                           Actual1 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts1, 1000),
+                           ?assertMatch({ok, {200, _, _}}, Actual1),
+                           Actual2 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts2, 1000),
+                           ?assertMatch({ok, {200, _, _}}, Actual2),
+                           %% Verify that different conn_opts values are pooled separately
+                           {ok, #uri{port = Port}} = honey_pool_uri:parse(Url),
+                           Key1 = {"localhost", Port, tcp, #{protocols => [http2], retry => 0}},
+                           Key2 = {"localhost", Port, tcp, #{protocols => [http2], retry => 1}},
+                           States = honey_pool:dump_state(),
+                           CountConns =
+                               fun(Key, SList) ->
+                                       lists:foldl(fun(S, Acc) ->
+                                                           Pool = maps:get(pool_conns, S),
+                                                           Acc + length(maps:get(Key, Pool, []))
+                                                   end, 0, SList)
+                               end,
+                           ?assertEqual(1, CountConns(Key1, States)),
+                           ?assertEqual(1, CountConns(Key2, States))
+                   end}],
              F = fun({Title, Test}) -> [{Title, Test}] end,
              lists:map(F, Cases)
      end}.

--- a/test/honey_pool_tests.erl
+++ b/test/honey_pool_tests.erl
@@ -103,22 +103,21 @@ request_test_() ->
                            Actual = honey_pool:get([Url, "/status/200/delay/50"], [], LegacyOpts, 1000),
                            ?assertMatch({ok, {200, _, _}}, Actual)
                    end},
-                  {"get: with http2 prior knowledge",
+                  {"get: with explicit protocols",
                    fun() ->
-                           %% Our cowboy test listener is configured with start_clear/3 (HTTP/1),
-                           %% so we include an HTTP/1 fallback alongside http2. This verifies
-                           %% that the protocols option is handled and that different conn_opts
-                           %% values result in separate pooled connections.
-                           ConnOpts1 = #{conn_opts => #{protocols => [http2, http], retry => 0}},
-                           ConnOpts2 = #{conn_opts => #{protocols => [http2, http], retry => 1}},
+                           %% For gun_tcp, gun expects exactly one protocol in the list.
+                           %% This verifies that the protocols option is handled and that
+                           %% different conn_opts values result in separate pooled connections.
+                           ConnOpts1 = #{conn_opts => #{protocols => [http], retry => 0}},
+                           ConnOpts2 = #{conn_opts => #{protocols => [http], retry => 1}},
                            Actual1 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts1, 1000),
                            ?assertMatch({ok, {200, _, _}}, Actual1),
                            Actual2 = honey_pool:get([Url, "/status/200/delay/10"], [], ConnOpts2, 1000),
                            ?assertMatch({ok, {200, _, _}}, Actual2),
                            %% Verify that different conn_opts values are pooled separately
                            {ok, #uri{port = Port}} = honey_pool_uri:parse(Url),
-                           Key1 = {"localhost", Port, tcp, #{protocols => [http2, http], retry => 0}},
-                           Key2 = {"localhost", Port, tcp, #{protocols => [http2, http], retry => 1}},
+                           Key1 = {"localhost", Port, tcp, #{protocols => [http], retry => 0}},
+                           Key2 = {"localhost", Port, tcp, #{protocols => [http], retry => 1}},
                            States = honey_pool:dump_state(),
                            CountConns =
                                fun(Key, SList) ->

--- a/test/honey_pool_worker_tests.erl
+++ b/test/honey_pool_worker_tests.erl
@@ -27,7 +27,7 @@ boot_server() ->
     Port = ranch:get_port(?LISTENER),
     [{apps, Apps},
      {port, Port},
-     {hostinfo, {"localhost", Port, tcp}}].
+     {hostinfo, {"localhost", Port, tcp, #{}}}].
 
 
 checkout_checkin_test_() ->


### PR DESCRIPTION
This PR adds support for connection-specific options (like `protocols => [http2]`) by including `ConnOpts` in the `hostinfo()` type. This ensures that connections with different settings are pooled separately and correctly.