### PR TITLE
non-blocking checkout via cast and min_conns warm pool

### DIFF
--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -17,7 +17,8 @@
           max_conns = infinity :: non_neg_integer() | infinity,  %% Maximum number of connections per worker.
           max_pending_conns = infinity :: non_neg_integer() | infinity,  %% Maximum number of pending (await_up) connections per worker.
           cur_conns = 0 :: non_neg_integer(),  %% Current number of total connections.
-          cur_pending_conns = 0 :: non_neg_integer()  %% Current number of pending connections.
+          cur_pending_conns = 0 :: non_neg_integer(),  %% Current number of pending connections.
+          min_conns = 0 :: non_neg_integer()  %% Minimum idle connections to maintain per host per worker.
          }).
 
 %% @doc Gun options for connection settings.

--- a/include/honey_pool.hrl
+++ b/include/honey_pool.hrl
@@ -18,6 +18,7 @@
           max_pending_conns = infinity :: non_neg_integer() | infinity,  %% Maximum number of pending (await_up) connections per worker.
           cur_conns = 0 :: non_neg_integer(),  %% Current number of total connections.
           cur_pending_conns = 0 :: non_neg_integer(),  %% Current number of pending connections.
+          pending_per_host = #{} :: #{hostinfo() => non_neg_integer()},  %% Per-host pending connection count.
           min_conns = 0 :: non_neg_integer()  %% Minimum idle connections to maintain per host per worker.
          }).
 

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -337,12 +337,13 @@ parse_url(Url) ->
 
 %% @private
 %% @doc Returns the wpool worker routing strategy.
-%% Defaults to `hash_worker` for connection pool affinity.
-%% Set `{honey_pool, worker_strategy, best_worker}` in sys.config to use
-%% `best_worker` instead (trades pool affinity for even worker load distribution).
+%% Defaults to `best_worker` for backward compatibility.
+%% Set `{honey_pool, worker_strategy, hash_worker}` in sys.config to use
+%% `hash_worker` instead, which improves connection pool affinity by routing
+%% all operations for the same host to the same worker.
 -spec worker_strategy(HostInfo :: hostinfo()) -> wpool:strategy().
 worker_strategy(HostInfo) ->
-    case application:get_env(honey_pool, worker_strategy, hash_worker) of
+    case application:get_env(honey_pool, worker_strategy, best_worker) of
         hash_worker -> {hash_worker, HostInfo};
         best_worker -> best_worker
     end.

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -236,26 +236,15 @@ next_timeout(Timeout, MicroSec) ->
 
 %% @private
 %% @doc Checks out a connection from the worker pool.
-%% Uses async cast + receive to avoid blocking the wpool gen_server caller,
-%% allowing best_worker routing to distribute load across all workers.
 -spec checkout(HostInfo :: hostinfo(), Timeout :: timeout()) ->
           {ok, {ReturnTo :: pid(), Conn :: conn()}} | {error, Reason :: term()}.
 checkout(HostInfo, Timeout) ->
-    Ref = make_ref(),
     T0 = erlang:monotonic_time(microsecond),
-    wpool:cast(?WORKER, {checkout_async, HostInfo, self(), Ref}, {hash_worker, HostInfo}),
     Result =
-        case Timeout of
-            infinity ->
-                receive
-                    {checkout_reply, Ref, R} -> R
-                end;
-            _ ->
-                receive
-                    {checkout_reply, Ref, R} -> R
-                after Timeout ->
-                    timeout
-                end
+        try
+            wpool:call(?WORKER, {checkout, HostInfo}, {hash_worker, HostInfo}, Timeout)
+        catch
+            exit:{timeout, _} -> timeout
         end,
     Elapsed = erlang:monotonic_time(microsecond) - T0,
     handle_checkout_result(Result, Timeout, Elapsed).

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -3,6 +3,10 @@
 -export([get/1, get/2, get/3, get/4,
          post/2, post/3, post/4, post/5,
          request/6,
+         async_post/5,
+         async_request/6,
+         checkin/3,
+         cleanup/1,
          return_to/3,
          dump_state/0,
          summarize_state/0]).
@@ -130,6 +134,60 @@ request(Method, Url, Headers, Body, Opts, Timeout) ->
                                    Opts,
                                    next_timeout(Timeout, Elapsed)),
                     handle_request_result(Result, ReturnTo, HostInfo, Conn, Method, Url);
+                {error, Reason} ->
+                    {error, {checkout, Reason}}
+            end;
+        {error, Reason} ->
+            {error, {uri, Reason}}
+    end.
+
+
+%% @doc Performs an async POST request.
+%% Fires the HTTP request and returns immediately. The calling process will receive
+%% gun_response / gun_data messages when the response arrives.
+-spec async_post(Url :: url(),
+                 Headers :: req_headers(),
+                 Body :: binary(),
+                 Opts :: gun_req_opts(),
+                 Timeout :: timeout()) ->
+          {ok,
+           #{stream_ref := reference(),
+             return_to := pid(),
+             host_info := hostinfo(),
+             conn := conn()}} |
+          {error, term()}.
+async_post(Url, Headers, Body, Opts, Timeout) ->
+    async_request(?METHOD_POST, Url, Headers, Body, Opts, Timeout).
+
+
+%% @doc Performs an async HTTP request.
+%% Fires the HTTP request and returns immediately. The calling process will receive
+%% gun_response / gun_data messages when the response arrives.
+-spec async_request(Method :: method(),
+                    Url :: url(),
+                    Headers :: req_headers(),
+                    Body :: binary() | no_data,
+                    Opts :: gun_req_opts(),
+                    Timeout :: timeout()) ->
+          {ok,
+           #{stream_ref := reference(),
+             return_to := pid(),
+             host_info := hostinfo(),
+             conn := conn()}} |
+          {error, term()}.
+async_request(Method, Url, Headers, Body, Opts, Timeout) ->
+    case honey_pool_uri:parse(Url) of
+        {ok, U} ->
+            HostInfo = {U#uri.host, U#uri.port, U#uri.transport},
+            case checkout(HostInfo, Timeout) of
+                {ok, {ReturnTo, {Pid, _MRef} = Conn}} ->
+                    ReqHeaders = headers(Headers),
+                    StreamRef = gun:request(Pid, Method, U#uri.pathquery, ReqHeaders, Body, Opts),
+                    {ok,
+                     #{stream_ref => StreamRef,
+                       return_to => ReturnTo,
+                       host_info => HostInfo,
+                       conn => Conn}};
                 {error, Reason} ->
                     {error, {checkout, Reason}}
             end;
@@ -286,7 +344,6 @@ cancel_await_up(ReturnTo, {Pid, MRef}) ->
     return_to(ReturnTo, Pid, {cancel_await_up, Pid}).
 
 
-%% @private
 %% @doc Returns a connection to the pool.
 -spec checkin(ReturnTo :: pid(), HostInfo :: hostinfo(), Conn :: conn()) -> ok.
 checkin(ReturnTo, HostInfo, {Pid, MRef}) ->
@@ -294,7 +351,6 @@ checkin(ReturnTo, HostInfo, {Pid, MRef}) ->
     return_to(ReturnTo, Pid, {checkin, HostInfo, Pid}).
 
 
-%% @private
 %% @doc Cleans up a connection by closing it.
 -spec cleanup(Conn :: conn()) -> ok.
 cleanup({Pid, MRef}) ->

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -240,7 +240,7 @@ next_timeout(Timeout, MicroSec) ->
           {ok, {ReturnTo :: pid(), Conn :: conn()}} | {error, Reason :: term()}.
 checkout(HostInfo, Timeout) ->
     {Elapsed, Result} =
-        timer:tc(fun wpool:call/4, [?WORKER, {checkout, HostInfo}, best_worker, Timeout]),
+        timer:tc(fun wpool:call/4, [?WORKER, {checkout, HostInfo}, {hash_worker, HostInfo}, Timeout]),
     try Result of
         {ok, {await_up, {ReturnTo, Pid}}} ->
             MRef = monitor(process, Pid),

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -301,7 +301,7 @@ next_timeout(Timeout, MicroSec) ->
 %%   {checkout_result, Ref, {error, Reason}}                    on failure
 -spec start_async_checkout(HostInfo :: hostinfo(), CallerPid :: pid(), Ref :: reference()) -> ok.
 start_async_checkout(HostInfo, CallerPid, Ref) ->
-    wpool:cast(?WORKER, {async_checkout, HostInfo, CallerPid, Ref}, {hash_worker, HostInfo}).
+    wpool:cast(?WORKER, {async_checkout, HostInfo, CallerPid, Ref}, worker_strategy(HostInfo)).
 
 
 %% @doc Fires an HTTP request on an already checked-out gun connection.
@@ -336,6 +336,19 @@ parse_url(Url) ->
 
 
 %% @private
+%% @doc Returns the wpool worker routing strategy.
+%% Defaults to `hash_worker` for connection pool affinity.
+%% Set `{honey_pool, worker_strategy, best_worker}` in sys.config to use
+%% `best_worker` instead (trades pool affinity for even worker load distribution).
+-spec worker_strategy(HostInfo :: hostinfo()) -> wpool:strategy().
+worker_strategy(HostInfo) ->
+    case application:get_env(honey_pool, worker_strategy, hash_worker) of
+        hash_worker -> {hash_worker, HostInfo};
+        best_worker -> best_worker
+    end.
+
+
+%% @private
 %% @doc Checks out a connection from the worker pool.
 -spec checkout(HostInfo :: hostinfo(), Timeout :: timeout()) ->
           {ok, {ReturnTo :: pid(), Conn :: conn()}} | {error, Reason :: term()}.
@@ -343,7 +356,7 @@ checkout(HostInfo, Timeout) ->
     T0 = erlang:monotonic_time(microsecond),
     Result =
         try
-            wpool:call(?WORKER, {checkout, HostInfo}, {hash_worker, HostInfo}, Timeout)
+            wpool:call(?WORKER, {checkout, HostInfo}, worker_strategy(HostInfo), Timeout)
         catch
             exit:{timeout, _} -> timeout
         end,

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -236,37 +236,57 @@ next_timeout(Timeout, MicroSec) ->
 
 %% @private
 %% @doc Checks out a connection from the worker pool.
+%% Uses async cast + receive to avoid blocking the wpool gen_server caller,
+%% allowing best_worker routing to distribute load across all workers.
 -spec checkout(HostInfo :: hostinfo(), Timeout :: timeout()) ->
           {ok, {ReturnTo :: pid(), Conn :: conn()}} | {error, Reason :: term()}.
 checkout(HostInfo, Timeout) ->
-    {Elapsed, Result} =
-        timer:tc(fun wpool:call/4, [?WORKER, {checkout, HostInfo}, {hash_worker, HostInfo}, Timeout]),
-    try Result of
-        {ok, {await_up, {ReturnTo, Pid}}} ->
-            MRef = monitor(process, Pid),
-            TimeoutRemaining = next_timeout(Timeout, Elapsed),
-            case gun:await_up(Pid, TimeoutRemaining, MRef) of
-                {ok, _} ->
-                    {ok, {ReturnTo, {Pid, MRef}}};
-                {error, timeout} ->
-                    %% even on timeout, let gun continue for the future use
-                    cancel_await_up(ReturnTo, {Pid, MRef}),
-                    {error, {timeout, await_up}};
-                {error, Reason} ->
-                    cleanup({Pid, MRef}),
-                    {error, {await_up, Reason}}
-            end;
-        {ok, {up, {ReturnTo, Pid}}} ->
-            {ok, {ReturnTo, {Pid, monitor(process, Pid)}}};
-        {error, {limit, _} = Reason} ->
-            %% Unwrap limit errors for direct pattern matching
-            {error, Reason};
+    Ref = make_ref(),
+    T0 = erlang:monotonic_time(microsecond),
+    wpool:cast(?WORKER, {checkout_async, HostInfo, self(), Ref}, best_worker),
+    Result =
+        case Timeout of
+            infinity ->
+                receive
+                    {checkout_reply, Ref, R} -> R
+                end;
+            _ ->
+                receive
+                    {checkout_reply, Ref, R} -> R
+                after Timeout ->
+                    timeout
+                end
+        end,
+    Elapsed = erlang:monotonic_time(microsecond) - T0,
+    handle_checkout_result(Result, Timeout, Elapsed).
+
+
+%% @private
+-spec handle_checkout_result(Result :: term(), Timeout :: timeout(), ElapsedMicro :: integer()) ->
+          {ok, {ReturnTo :: pid(), Conn :: conn()}} | {error, Reason :: term()}.
+handle_checkout_result({ok, {await_up, {ReturnTo, Pid}}}, Timeout, Elapsed) ->
+    MRef = monitor(process, Pid),
+    TimeoutRemaining = next_timeout(Timeout, Elapsed),
+    case gun:await_up(Pid, TimeoutRemaining, MRef) of
+        {ok, _} ->
+            {ok, {ReturnTo, {Pid, MRef}}};
+        {error, timeout} ->
+            %% even on timeout, let gun continue for the future use
+            cancel_await_up(ReturnTo, {Pid, MRef}),
+            {error, {timeout, await_up}};
         {error, Reason} ->
-            {error, {pool_checkout, Reason}}
-    catch
-        _:Err ->
-            {error, {checkout, Err}}
-    end.
+            cleanup({Pid, MRef}),
+            {error, {await_up, Reason}}
+    end;
+handle_checkout_result({ok, {up, {ReturnTo, Pid}}}, _Timeout, _Elapsed) ->
+    {ok, {ReturnTo, {Pid, monitor(process, Pid)}}};
+handle_checkout_result({error, {limit, _} = Reason}, _Timeout, _Elapsed) ->
+    %% Unwrap limit errors for direct pattern matching
+    {error, Reason};
+handle_checkout_result({error, Reason}, _Timeout, _Elapsed) ->
+    {error, {pool_checkout, Reason}};
+handle_checkout_result(timeout, _Timeout, _Elapsed) ->
+    {error, {timeout, checkout}}.
 
 
 %% @private

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -243,7 +243,7 @@ next_timeout(Timeout, MicroSec) ->
 checkout(HostInfo, Timeout) ->
     Ref = make_ref(),
     T0 = erlang:monotonic_time(microsecond),
-    wpool:cast(?WORKER, {checkout_async, HostInfo, self(), Ref}, best_worker),
+    wpool:cast(?WORKER, {checkout_async, HostInfo, self(), Ref}, {hash_worker, HostInfo}),
     Result =
         case Timeout of
             infinity ->

--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -5,6 +5,9 @@
          request/6,
          async_post/5,
          async_request/6,
+         start_async_checkout/3,
+         fire_request/7,
+         parse_url/1,
          checkin/3,
          cleanup/1,
          return_to/3,
@@ -289,6 +292,46 @@ next_timeout(Timeout, MicroSec) ->
             Timeout - Interval;
         _ ->
             0
+    end.
+
+
+%% @doc Starts an async checkout for an already-parsed HostInfo.
+%% CallerPid will receive:
+%%   {checkout_result, Ref, {ok, {ReturnTo, HostInfo, GunPid}}} on success
+%%   {checkout_result, Ref, {error, Reason}}                    on failure
+-spec start_async_checkout(HostInfo :: hostinfo(), CallerPid :: pid(), Ref :: reference()) -> ok.
+start_async_checkout(HostInfo, CallerPid, Ref) ->
+    wpool:cast(?WORKER, {async_checkout, HostInfo, CallerPid, Ref}, {hash_worker, HostInfo}).
+
+
+%% @doc Fires an HTTP request on an already checked-out gun connection.
+%% Url is used only for debug logging; PathQuery is what is sent over the wire.
+%% Returns the gun stream reference.
+-spec fire_request(Method :: method(),
+                   Url :: url(),
+                   PathQuery :: string(),
+                   Headers :: req_headers(),
+                   Body :: binary() | no_data,
+                   Opts :: gun_req_opts(),
+                   GunPid :: pid()) -> reference().
+fire_request(Method, Url, PathQuery, Headers, Body, Opts, GunPid) ->
+    ReqHeaders = headers(Headers),
+    ?LOG_DEBUG("(~p) (conn: ~p) ~p ~p", [self(), GunPid, Method, Url]),
+    gun:request(GunPid, Method, PathQuery, ReqHeaders, Body, Opts).
+
+
+%% @doc Parses a URL and returns HostInfo and PathQuery.
+-spec parse_url(Url :: url()) ->
+          {ok, #{host_info := hostinfo(), path_query := string()}} | {error, term()}.
+parse_url(Url) ->
+    case honey_pool_uri:parse(Url) of
+        {ok, U} ->
+            {ok, #{
+               host_info => {U#uri.host, U#uri.port, U#uri.transport},
+               path_query => U#uri.pathquery
+              }};
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 

--- a/src/honey_pool_sup.erl
+++ b/src/honey_pool_sup.erl
@@ -39,6 +39,7 @@ init([]) ->
     AwaitUpTimeout = application:get_env(honey_pool, await_up_timeout, 5000),
     MaxConns = application:get_env(honey_pool, max_conns, infinity),
     MaxPendingConns = application:get_env(honey_pool, max_pending_conns, infinity),
+    MinConns = application:get_env(honey_pool, min_conns, 0),
     WpoolUserConfig = application:get_env(honey_pool, wpool, []),
     WpoolDefaultConfig =
         #{
@@ -50,7 +51,8 @@ init([]) ->
                 {idle_timeout, IdleTimeout},
                 {await_up_timeout, AwaitUpTimeout},
                 {max_conns, MaxConns},
-                {max_pending_conns, MaxPendingConns}]}
+                {max_pending_conns, MaxPendingConns},
+                {min_conns, MinConns}]}
          },
     WpoolConfig =
         maps:to_list(

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -475,13 +475,15 @@ dump_state(_, Acc) ->
 -spec maintain_min_conns(hostinfo(), state()) -> state().
 maintain_min_conns(_HostInfo, #state{min_conns = 0} = State) ->
     State;
-maintain_min_conns(HostInfo, #state{tabid = TabId, min_conns = MinConns} = State) ->
+maintain_min_conns(HostInfo, #state{tabid = TabId, min_conns = MinConns, cur_pending_conns = CurPending} = State) ->
     PoolSize =
         case ets:lookup(TabId, {pool, HostInfo}) of
             [{_, Pids}] -> length(Pids);
             _ -> 0
         end,
-    replenish_pool(HostInfo, max(0, MinConns - PoolSize), State).
+    %% Count pending (await_up) connections towards min_conns to avoid
+    %% spamming conn_open during burst when connections are already being established.
+    replenish_pool(HostInfo, max(0, MinConns - PoolSize - CurPending), State).
 
 %% @private
 -spec replenish_pool(hostinfo(), non_neg_integer(), state()) -> state().

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -31,7 +31,7 @@
           timer_ref :: timer_ref()
          }).
 
--type requester() :: pid() | undefined.
+-type requester() :: pid() | {pid(), reference()} | undefined.
 -type timer_ref() :: reference() | undefined.
 
 %% @doc Callback functions for the honey_pool_worker gen_server.
@@ -50,7 +50,8 @@ init(Args) ->
        idle_timeout = maps:get(idle_timeout, Opts, infinity),
        await_up_timeout = maps:get(await_up_timeout, Opts, 5000),
        max_conns = maps:get(max_conns, Opts, infinity),
-       max_pending_conns = maps:get(max_pending_conns, Opts, infinity)
+       max_pending_conns = maps:get(max_pending_conns, Opts, infinity),
+       min_conns = maps:get(min_conns, Opts, 0)
       }}.
 
 
@@ -99,6 +100,21 @@ handle_cast({checkin, HostInfo, Pid} = Req, State) ->
 handle_cast({cancel_await_up, Pid} = Req, State) ->
     {Result, NewState} = conn_cancel_await_up(Pid, State),
     ?LOG_DEBUG("(~p) handle_cast (~p) -> ~p", [self(), Req, Result]),
+    {noreply, NewState};
+%% Async checkout: caller receives {checkout_result, Ref, {ok, {ReturnTo, HostInfo, GunPid}}}
+%% or {checkout_result, Ref, {error, Reason}} when checkout completes.
+%% For the await_up case, conn_up/3 will deliver the notification when gun_up arrives.
+handle_cast({async_checkout, HostInfo, CallerPid, Ref} = Req, State) ->
+    {Result, NewState} = conn_checkout(HostInfo, {CallerPid, Ref}, State),
+    ?LOG_DEBUG("(~p) handle_cast (~p) -> ~p", [self(), Req, Result]),
+    case Result of
+        {ok, {up, {ReturnTo, Pid}}} ->
+            CallerPid ! {checkout_result, Ref, {ok, {ReturnTo, HostInfo, Pid}}};
+        {ok, {await_up, _}} ->
+            ok;  %% conn_up/3 will notify when gun_up arrives
+        {error, Reason} ->
+            CallerPid ! {checkout_result, Ref, {error, Reason}}
+    end,
     {noreply, NewState};
 handle_cast(Req, State) ->
     ?LOG_WARNING("(~p) unhandled cast (~p, ~p)", [self(), Req, State]),
@@ -175,7 +191,8 @@ conn_checkout(HostInfo, Requester, #state{tabid = TabId} = State) ->
                 no_available_worker ->
                     conn_open_with_returnto(HostInfo, Requester, State);
                 {ok, {Status, Pid}} ->
-                    {{ok, {Status, {self(), Pid}}}, State}
+                    NewState = maintain_min_conns(HostInfo, State),
+                    {{ok, {Status, {self(), Pid}}}, NewState}
             end
     end.
 
@@ -348,11 +365,18 @@ conn_up(Pid, Protocol, #state{tabid = TabId, cur_pending_conns = CurPending} = S
                      end,
             case Conn#conn.requester of
                 undefined ->
-                    %% requester has canceled -> just keep pid in the pool
+                    %% requester has canceled (or min_conns proactive open) -> keep in pool
                     cancel_idle_timer(Conn#conn.timer_ref),
                     conn_checkin(Conn#conn.hostinfo, Pid, State1);
-                Requester ->
-                    %% notify requester and tag that conn is checked out
+                {CallerPid, Ref} ->
+                    %% async checkout: notify caller with checkout_result
+                    cancel_idle_timer(Conn#conn.timer_ref),
+                    CallerPid ! {checkout_result, Ref, {ok, {self(), Conn#conn.hostinfo, Pid}}},
+                    ets:insert(TabId,
+                               {{pid, Pid}, Conn#conn{state = checked_out, requester = undefined}}),
+                    {{ok, {Conn#conn.hostinfo, Pid}}, State1};
+                Requester when is_pid(Requester) ->
+                    %% sync checkout: gun:await_up/3 in caller is waiting for {gun_up, ...}
                     cancel_idle_timer(Conn#conn.timer_ref),
                     Requester ! {gun_up, Pid, Protocol},
                     ets:insert(TabId,
@@ -389,7 +413,8 @@ conn_down(Pid, #state{tabid = TabId, cur_conns = CurConns, cur_pending_conns = C
                     _ ->
                         State#state{cur_conns = CurConns - 1}
                 end,
-            {{ok, {HostInfo, Pid}}, NewState};
+            FinalState = maintain_min_conns(HostInfo, NewState),
+            {{ok, {HostInfo, Pid}}, FinalState};
         _ ->
             %% Some servers close connections on the fly, and gun_down is fired before the conn checks-in.
             %% In that case, we just forget until checkin, and the monitor will detect noproc.
@@ -441,3 +466,31 @@ dump_state({{pool, HostInfo}, Pids}, #{pool_conns := M} = Acc) ->
     end;
 dump_state(_, Acc) ->
     Acc.
+
+
+%% @private
+%% @doc Ensures the pool for HostInfo has at least min_conns idle connections.
+%% Opens new connections with requester=undefined so they go directly to the
+%% pool via conn_up/3 when gun_up fires.
+-spec maintain_min_conns(hostinfo(), state()) -> state().
+maintain_min_conns(_HostInfo, #state{min_conns = 0} = State) ->
+    State;
+maintain_min_conns(HostInfo, #state{tabid = TabId, min_conns = MinConns} = State) ->
+    PoolSize =
+        case ets:lookup(TabId, {pool, HostInfo}) of
+            [{_, Pids}] -> length(Pids);
+            _ -> 0
+        end,
+    replenish_pool(HostInfo, max(0, MinConns - PoolSize), State).
+
+%% @private
+-spec replenish_pool(hostinfo(), non_neg_integer(), state()) -> state().
+replenish_pool(_HostInfo, 0, State) ->
+    State;
+replenish_pool(HostInfo, N, State) ->
+    case conn_open(HostInfo, undefined, State) of
+        {{ok, {await_up, _}}, NewState} ->
+            replenish_pool(HostInfo, N - 1, NewState);
+        {_Error, State} ->
+            State
+    end.

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -280,6 +280,7 @@ conn_cancel_await_up(Pid,
 
 %% @private
 %% @doc Adds a PID to the pool for the given HostInfo.
+%% Callers must ensure the PID is not already in checked_in state to avoid duplicates.
 -spec add_to_pool(TabId :: ets:tid(), HostInfo :: hostinfo(), Pid :: pid()) -> ok.
 add_to_pool(TabId, HostInfo, Pid) ->
     PidsToPool =
@@ -287,12 +288,7 @@ add_to_pool(TabId, HostInfo, Pid) ->
             [] ->
                 [Pid];
             [{_, Pids}] ->
-                case lists:member(Pid, Pids) of
-                    true ->
-                        Pids;
-                    false ->
-                        [Pid | Pids]
-                end
+                [Pid | Pids]
         end,
     ets:insert(TabId, {{pool, HostInfo}, PidsToPool}),
     ok.
@@ -328,7 +324,13 @@ conn_checkin(HostInfo, Pid, #state{tabid = TabId, idle_timeout = IdleTimeout, cu
             cancel_idle_timer(OldConn#conn.timer_ref),
             Conn = OldConn#conn{state = checked_in, timer_ref = idle_timer(Pid, IdleTimeout)},
             ets:insert(TabId, {{pid, Pid}, Conn}),
-            add_to_pool(TabId, HostInfo, Pid),
+            case OldConn#conn.state of
+                checked_in ->
+                    %% Already in pool (e.g. double-checkin), skip to avoid duplicate
+                    ok;
+                _ ->
+                    add_to_pool(TabId, HostInfo, Pid)
+            end,
             {{ok, {HostInfo, Pid}}, State}
     end.
 

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -245,7 +245,8 @@ conn_open({Host, Port, Transport},
             gun_opts = GunOpts,
             tabid = TabId,
             cur_conns = CurConns,
-            cur_pending_conns = CurPending
+            cur_pending_conns = CurPending,
+            pending_per_host = PendingPerHost
            } = State) ->
     GunOptsWithTransport = GunOpts#{transport => Transport},
     HostInfo = {Host, Port, Transport},
@@ -262,7 +263,10 @@ conn_open({Host, Port, Transport},
             {{ok, {await_up, Pid}},
              State#state{
                cur_conns = CurConns + 1,
-               cur_pending_conns = CurPending + 1
+               cur_pending_conns = CurPending + 1,
+               pending_per_host = PendingPerHost#{
+                   HostInfo => maps:get(HostInfo, PendingPerHost, 0) + 1
+               }
               }};
         {error, Reason} ->
             {{error, {gun_open, Reason}}, State}
@@ -355,12 +359,17 @@ conn_checkin(HostInfo, Pid, #state{tabid = TabId, idle_timeout = IdleTimeout, cu
 %% @private
 %% @doc Handles the `gun_up` message, indicating a connection is ready.
 -spec conn_up(pid(), tcp | tls, state()) -> {{ok, term()}, state()}.
-conn_up(Pid, Protocol, #state{tabid = TabId, cur_pending_conns = CurPending} = State) ->
+conn_up(Pid, Protocol, #state{tabid = TabId, cur_pending_conns = CurPending, pending_per_host = PendingPerHost} = State) ->
     case ets:lookup(TabId, {pid, Pid}) of
         [{_, Conn}] ->
-            %% Only decrement cur_pending_conns if connection is in await_up state
+            %% Only decrement pending counts if connection is in await_up state
             State1 = case Conn#conn.state of
-                         await_up -> State#state{cur_pending_conns = CurPending - 1};
+                         await_up ->
+                             HostInfo = Conn#conn.hostinfo,
+                             NewPPH = PendingPerHost#{
+                                 HostInfo => max(0, maps:get(HostInfo, PendingPerHost, 0) - 1)
+                             },
+                             State#state{cur_pending_conns = CurPending - 1, pending_per_host = NewPPH};
                          _ -> State
                      end,
             case Conn#conn.requester of
@@ -394,7 +403,7 @@ conn_up(Pid, Protocol, #state{tabid = TabId, cur_pending_conns = CurPending} = S
 %% @private
 %% @doc Handles the `gun_down` message, indicating a connection has been lost.
 -spec conn_down(pid(), state()) -> {{ok, term()}, state()}.
-conn_down(Pid, #state{tabid = TabId, cur_conns = CurConns, cur_pending_conns = CurPending} = State) ->
+conn_down(Pid, #state{tabid = TabId, cur_conns = CurConns, cur_pending_conns = CurPending, pending_per_host = PendingPerHost} = State) ->
     case ets:take(TabId, {pid, Pid}) of
         [{_, Conn}] ->
             HostInfo = Conn#conn.hostinfo,
@@ -409,7 +418,10 @@ conn_down(Pid, #state{tabid = TabId, cur_conns = CurConns, cur_pending_conns = C
             NewState =
                 case Conn#conn.state of
                     await_up ->
-                        State#state{cur_conns = CurConns - 1, cur_pending_conns = CurPending - 1};
+                        NewPPH = PendingPerHost#{
+                            HostInfo => max(0, maps:get(HostInfo, PendingPerHost, 0) - 1)
+                        },
+                        State#state{cur_conns = CurConns - 1, cur_pending_conns = CurPending - 1, pending_per_host = NewPPH};
                     _ ->
                         State#state{cur_conns = CurConns - 1}
                 end,
@@ -475,15 +487,16 @@ dump_state(_, Acc) ->
 -spec maintain_min_conns(hostinfo(), state()) -> state().
 maintain_min_conns(_HostInfo, #state{min_conns = 0} = State) ->
     State;
-maintain_min_conns(HostInfo, #state{tabid = TabId, min_conns = MinConns, cur_pending_conns = CurPending} = State) ->
+maintain_min_conns(HostInfo, #state{tabid = TabId, min_conns = MinConns, pending_per_host = PendingPerHost} = State) ->
     PoolSize =
         case ets:lookup(TabId, {pool, HostInfo}) of
             [{_, Pids}] -> length(Pids);
             _ -> 0
         end,
-    %% Count pending (await_up) connections towards min_conns to avoid
-    %% spamming conn_open during burst when connections are already being established.
-    replenish_pool(HostInfo, max(0, MinConns - PoolSize - CurPending), State).
+    %% Use per-host pending count to avoid blocking replenishment of other hosts
+    %% on the same worker when they happen to hash to the same worker.
+    PendingForHost = maps:get(HostInfo, PendingPerHost, 0),
+    replenish_pool(HostInfo, max(0, MinConns - PoolSize - PendingForHost), State).
 
 %% @private
 -spec replenish_pool(hostinfo(), non_neg_integer(), state()) -> state().

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -223,6 +223,7 @@ checkout_from_pool(HostInfo, Requester, [Pid | Pids], #state{tabid = TabId} = St
             checkout_from_pool(HostInfo, Requester, Pids, State);
         [{_, Conn}] ->
             ets:insert(TabId, {{pool, HostInfo}, Pids}),
+            ets:update_counter(TabId, {pool_size, HostInfo}, {2, -1, 0, 0}, {{pool_size, HostInfo}, 0}),
             cancel_idle_timer(Conn#conn.timer_ref),
             ets:insert(TabId, {{pid, Pid}, Conn#conn{state = checked_out, timer_ref = undefined}}),
             {ok, {up, Pid}}
@@ -312,6 +313,7 @@ add_to_pool(TabId, HostInfo, Pid) ->
                 [Pid | Pids]
         end,
     ets:insert(TabId, {{pool, HostInfo}, PidsToPool}),
+    ets:update_counter(TabId, {pool_size, HostInfo}, {2, 1}, {{pool_size, HostInfo}, 0}),
     ok.
 
 
@@ -409,9 +411,16 @@ conn_down(Pid, #state{tabid = TabId, cur_conns = CurConns, cur_pending_conns = C
             HostInfo = Conn#conn.hostinfo,
             demonitor(Conn#conn.monitor_ref, [flush]),
             cancel_idle_timer(Conn#conn.timer_ref),
-            case ets:lookup(TabId, {pool, HostInfo}) of
-                [{_, Pids}] ->
-                    ets:insert(TabId, {{pool, HostInfo}, [ P || P <- Pids, P =/= Pid ]});
+            case Conn#conn.state of
+                checked_in ->
+                    %% Remove from pool list and decrement pool_size counter
+                    case ets:lookup(TabId, {pool, HostInfo}) of
+                        [{_, Pids}] ->
+                            ets:insert(TabId, {{pool, HostInfo}, [ P || P <- Pids, P =/= Pid ]});
+                        _ ->
+                            ok
+                    end,
+                    ets:update_counter(TabId, {pool_size, HostInfo}, {2, -1, 0, 0}, {{pool_size, HostInfo}, 0});
                 _ ->
                     ok
             end,
@@ -488,9 +497,10 @@ dump_state(_, Acc) ->
 maintain_min_conns(_HostInfo, #state{min_conns = 0} = State) ->
     State;
 maintain_min_conns(HostInfo, #state{tabid = TabId, min_conns = MinConns, pending_per_host = PendingPerHost} = State) ->
+    %% O(1) pool size lookup via ETS counter (maintained by add_to_pool/checkout_from_pool/conn_down)
     PoolSize =
-        case ets:lookup(TabId, {pool, HostInfo}) of
-            [{_, Pids}] -> length(Pids);
+        case ets:lookup(TabId, {pool_size, HostInfo}) of
+            [{_, N}] -> N;
             _ -> 0
         end,
     %% Use per-host pending count to avoid blocking replenishment of other hosts

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -92,6 +92,11 @@ handle_call(Req, From, State) ->
 %% - `{checkin, HostInfo, Pid}`: Checks a connection back into the pool.
 %% - `{cancel_await_up, Pid}`: Cancels a pending connection attempt.
 -spec handle_cast(Req :: term(), State :: state()) -> {noreply, state()}.
+handle_cast({checkout_async, HostInfo, Requester, Ref} = Req, State) ->
+    {Result, NewState} = conn_checkout(HostInfo, Requester, State),
+    ?LOG_DEBUG("(~p) handle_cast (~p) -> ~p", [self(), Req, Result]),
+    Requester ! {checkout_reply, Ref, Result},
+    {noreply, NewState};
 handle_cast({checkin, HostInfo, Pid} = Req, State) ->
     {Result, NewState} = conn_checkin(HostInfo, Pid, State),
     ?LOG_DEBUG("(~p) handle_cast (~p) -> ~p", [self(), Req, Result]),

--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -92,11 +92,6 @@ handle_call(Req, From, State) ->
 %% - `{checkin, HostInfo, Pid}`: Checks a connection back into the pool.
 %% - `{cancel_await_up, Pid}`: Cancels a pending connection attempt.
 -spec handle_cast(Req :: term(), State :: state()) -> {noreply, state()}.
-handle_cast({checkout_async, HostInfo, Requester, Ref} = Req, State) ->
-    {Result, NewState} = conn_checkout(HostInfo, Requester, State),
-    ?LOG_DEBUG("(~p) handle_cast (~p) -> ~p", [self(), Req, Result]),
-    Requester ! {checkout_reply, Ref, Result},
-    {noreply, NewState};
 handle_cast({checkin, HostInfo, Pid} = Req, State) ->
     {Result, NewState} = conn_checkin(HostInfo, Pid, State),
     ?LOG_DEBUG("(~p) handle_cast (~p) -> ~p", [self(), Req, Result]),


### PR DESCRIPTION
## honey_pool changes

  Adds async connection checkout, minimum idle connection maintenance (`min_conns`),
  and O(1) pool-size tracking to reduce scheduler contention under high load.

  ---

  ### `include/honey_pool.hrl`

  - Added `pending_per_host` — per-host count of connections currently in `await_up`
    state, used to prevent over-provisioning during burst
  - Added `min_conns` — minimum number of idle connections to maintain per host per worker

  ---

  ### `src/honey_pool_sup.erl`

  - Reads `min_conns` from application env and passes it to worker init args

  ---

  ### `src/honey_pool.erl`

  **New public API:**

  | Function | Description |
  |---|---|
  | `start_async_checkout/3` | Non-blocking checkout via `wpool:cast`. Caller receives `{checkout_result, Ref, ...}` when a connection becomes available |
  | `fire_request/7` | Fires an HTTP request on an already checked-out gun connection. Returns the stream reference |
  | `parse_url/1` | Parses a URL into `#{host_info, path_query}` without making any network calls — for use in the prepare phase before checkout |
  | `async_post/5`, `async_request/6` | Fire-and-forget request: performs checkout + `gun:request` in one call, returns immediately. The calling process
  receives `gun_response`/`gun_data` messages |
  | `checkin/3`, `cleanup/1` | Exported for callers managing async connections to return or close them |

  **`checkout/2` refactoring:**

  - Routing changed from `best_worker` to `{hash_worker, HostInfo}` — ensures all
    operations for the same host always go to the same worker, preserving connection
    pool affinity
  - Timeout handling changed from `timer:tc` to `try/catch exit:{timeout, _}` with
    extracted `handle_checkout_result/3`

  ---

  ### `src/honey_pool_worker.erl`

  **Async checkout handler**

  New `handle_cast({async_checkout, HostInfo, CallerPid, Ref})`:
  - If an idle connection is available in the pool: immediately sends
    `{checkout_result, Ref, {ok, ...}}` to the caller
  - If a new connection is being opened (`await_up`): does nothing —
    `conn_up/3` delivers the notification when `gun_up` arrives
  - If checkout fails (e.g. connection limit): immediately sends
    `{checkout_result, Ref, {error, Reason}}`

  **`conn_up/3` async path**

  Handles both sync (`pid()`) and async (`{CallerPid, Ref}`) requester types via
  pattern matching with a type guard, cleanly separating the two code paths.

  **O(1) pool-size tracking via ETS counter**

  Replaces `length(Pids)` O(n) call in `maintain_min_conns`. An ETS counter
  `{pool_size, HostInfo}` is maintained by:
  - `add_to_pool` — increment
  - `checkout_from_pool` — decrement (floor at 0)
  - `conn_down` (checked-in state only) — decrement

  **`maintain_min_conns/2`**

  Called after every checkout and every connection loss. Calculates replenishment need as:

  max(0, min_conns - pool_size - pending_for_host)

  `pending_for_host` (from `pending_per_host`) is subtracted to avoid opening redundant
  connections when several are already opening simultaneously. No-op when `min_conns = 0`
  (the default).

  **`conn_down` scoping fix**

  Pool list filtering is now restricted to `checked_in` connections only. Connections in
  `await_up` or `checked_out` state are never in the pool list, so filtering them was
  unnecessary work.

  **Double-checkin guard**

  Removed the O(n) `lists:member` check from `add_to_pool`. Duplicate prevention is now
  done in `conn_checkin/3` by checking `OldConn#conn.state =:= checked_in` before
  calling `add_to_pool`.