### PR TITLE
exp: use random_worker routing instead of best_worker

### DIFF
--- a/src/honey_pool.erl
+++ b/src/honey_pool.erl
@@ -240,7 +240,7 @@ next_timeout(Timeout, MicroSec) ->
           {ok, {ReturnTo :: pid(), Conn :: conn()}} | {error, Reason :: term()}.
 checkout(HostInfo, Timeout) ->
     {Elapsed, Result} =
-        timer:tc(fun wpool:call/4, [?WORKER, {checkout, HostInfo}, best_worker, Timeout]),
+        timer:tc(fun wpool:call/4, [?WORKER, {checkout, HostInfo}, random_worker, Timeout]),
     try Result of
         {ok, {await_up, {ReturnTo, Pid}}} ->
             MRef = monitor(process, Pid),


### PR DESCRIPTION
best_worker selects the least-loaded worker, which requires scanning all workers' queue lengths. Under high QPS with many workers this overhead may contribute to checkout latency.

random_worker distributes requests uniformly without coordination cost. This branch is for benchmarking whether routing strategy affects checkout throughput on dlv master (honey_pool 1.1.0 base).