### PR TITLE
perf: avoid O(n) lists:member in add_to_pool

### DIFF
--- a/src/honey_pool_worker.erl
+++ b/src/honey_pool_worker.erl
@@ -281,6 +281,7 @@ conn_cancel_await_up(Pid,
 
 %% @private
 %% @doc Adds a PID to the pool for the given HostInfo.
+%% Callers must ensure the PID is not already in checked_in state to avoid duplicates.
 -spec add_to_pool(TabId :: ets:tid(), HostInfo :: hostinfo(), Pid :: pid()) -> ok.
 add_to_pool(TabId, HostInfo, Pid) ->
     PidsToPool =
@@ -288,12 +289,7 @@ add_to_pool(TabId, HostInfo, Pid) ->
             [] ->
                 [Pid];
             [{_, Pids}] ->
-                case lists:member(Pid, Pids) of
-                    true ->
-                        Pids;
-                    false ->
-                        [Pid | Pids]
-                end
+                [Pid | Pids]
         end,
     ets:insert(TabId, {{pool, HostInfo}, PidsToPool}),
     ok.
@@ -329,7 +325,13 @@ conn_checkin(HostInfo, Pid, #state{tabid = TabId, idle_timeout = IdleTimeout, cu
             cancel_idle_timer(OldConn#conn.timer_ref),
             Conn = OldConn#conn{state = checked_in, timer_ref = idle_timer(Pid, IdleTimeout)},
             ets:insert(TabId, {{pid, Pid}, Conn}),
-            add_to_pool(TabId, HostInfo, Pid),
+            case OldConn#conn.state of
+                checked_in ->
+                    %% Already in pool (e.g. double-checkin), skip to avoid duplicate
+                    ok;
+                _ ->
+                    add_to_pool(TabId, HostInfo, Pid)
+            end,
             {{ok, {HostInfo, Pid}}, State}
     end.
 


### PR DESCRIPTION
## 概要

`add_to_pool/3` の重複チェックに使われている `lists:member/2`（プールリストの全走査 O(n)）を排除し、`conn_checkin/3` 側で ETS に保持している接続 state の O(1) チェックに置き換えます。

既存接続の state が `checked_in` の場合（double-checkin 等）は既にプールに入っているため `add_to_pool` をスキップし、それ以外の場合のみ追加します。`add_to_pool` のもう一方の呼び出し元（unknown PID の checkin）は `{pid, Pid}` エントリが存在しないケースなのでプールに重複は発生しません。

## 背景

高負荷時（数百〜千 checkout/秒/worker）に gen_server コールバックごとのプールリスト走査がワーカーのメッセージキュー滞留を悪化させていました。fluct の HB インスタンスでの負荷テストでは、この変更により 499 エラーの爆発閾値が ~670 QPS → ~841 QPS に改善しています（単機・実トラフィックミラー環境での実測）。

## テスト

- `rebar3 eunit`: 28 tests, 0 failures

## 補足

#43 に同梱されていた変更のうち、独立して効果が確認できているこの修正だけを切り出したものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)